### PR TITLE
회원가입 api 1차 완성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // gson (테스트 코드 작성할 때 반환 받을 정보를 객체 타입이 아닌 문자열 타입으로 받기 위함.)
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/zzapdiz/ZzapdizApplication.java
+++ b/src/main/java/com/example/zzapdiz/ZzapdizApplication.java
@@ -2,7 +2,9 @@ package com.example.zzapdiz;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ZzapdizApplication {
 

--- a/src/main/java/com/example/zzapdiz/configuration/SecurityConfig.java
+++ b/src/main/java/com/example/zzapdiz/configuration/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
                 .antMatchers("/js/**",
                         "/css/**",
                         "/assets/**").permitAll()
+                .antMatchers("/zzapdiz/signup").permitAll()
                 .antMatchers("/test").hasRole("USER")
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/com/example/zzapdiz/exception/MemberException.java
+++ b/src/main/java/com/example/zzapdiz/exception/MemberException.java
@@ -1,0 +1,54 @@
+package com.example.zzapdiz.exception;
+
+import com.example.zzapdiz.member.request.MemberSignupRequestDto;
+import com.example.zzapdiz.share.ResponseBody;
+import com.example.zzapdiz.share.StatusCode;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import static com.example.zzapdiz.member.domain.QMember.member;
+
+@RequiredArgsConstructor
+@Component
+public class MemberException implements MemberExceptionInterface{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    // 회원가입용 비밀번호와 재확인용 비밀번호 일치여부 확인
+    @Override
+    public ResponseEntity<ResponseBody> matchPassword(String password, String passwordRecheck) {
+        if(!password.equals(passwordRecheck)){
+            return new ResponseEntity<>(new ResponseBody(StatusCode.NOT_MATCH_PASSWORD, null), HttpStatus.BAD_REQUEST);
+        }
+        return null;
+    }
+
+    // 이미 가입한 적이 있는 회원인지 확인
+    @Override
+    public ResponseEntity<ResponseBody> alreadyExistMember(String email) {
+        if(jpaQueryFactory
+                .selectFrom(member)
+                .where(member.email.eq(email))
+                .fetchOne() != null){
+            return new ResponseEntity<>(new ResponseBody(StatusCode.ALREADY_EXIST_MEMBER, null), HttpStatus.BAD_REQUEST);
+        }
+        return null;
+    }
+
+    // 회원가입 정보가 하나라도 비워져있으면 에러 처리
+    @Override
+    public ResponseEntity<ResponseBody> allRequestDataCheck(MemberSignupRequestDto memberSignupRequestDto) {
+        if(memberSignupRequestDto.getMemberName() == null ||
+            memberSignupRequestDto.getPassword() == null ||
+            memberSignupRequestDto.getEmail() == null ||
+            memberSignupRequestDto.getPasswordRecheck() == null){
+            return new ResponseEntity<>(new ResponseBody(StatusCode.EXIST_INCORRECTABLE_DATA, null), HttpStatus.BAD_REQUEST);
+        }
+        return null;
+    }
+
+
+}

--- a/src/main/java/com/example/zzapdiz/exception/MemberExceptionInterface.java
+++ b/src/main/java/com/example/zzapdiz/exception/MemberExceptionInterface.java
@@ -1,0 +1,19 @@
+package com.example.zzapdiz.exception;
+
+import com.example.zzapdiz.member.request.MemberSignupRequestDto;
+import com.example.zzapdiz.share.ResponseBody;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface MemberExceptionInterface {
+
+    /** 회원가입 시 입력한 비밀번호와 재확인용 비밀번호 일치 여부 확인 **/
+    ResponseEntity<ResponseBody> matchPassword(String password, String passwordRecheck);
+
+    /** 이미 존재한 회원인지 확인 **/
+    ResponseEntity<ResponseBody> alreadyExistMember(String email);
+
+    /** 회원가입 정보가 모두 정상적으로 적혀있는지 확인 **/
+    ResponseEntity<ResponseBody> allRequestDataCheck(MemberSignupRequestDto memberSignupRequestDto);
+}

--- a/src/main/java/com/example/zzapdiz/member/controller/MemberController.java
+++ b/src/main/java/com/example/zzapdiz/member/controller/MemberController.java
@@ -1,0 +1,29 @@
+package com.example.zzapdiz.member.controller;
+
+import com.example.zzapdiz.member.request.MemberSignupRequestDto;
+import com.example.zzapdiz.member.service.MemberService;
+import com.example.zzapdiz.share.ResponseBody;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/zzapdiz")
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    // 회원가입
+    @PostMapping("/signup")
+    public ResponseEntity<ResponseBody> memberSignUp(@RequestBody MemberSignupRequestDto memberSignupRequestDto){
+        log.info("회원가입 api : 이메일 - {}, 이름 - {}", memberSignupRequestDto.getEmail(), memberSignupRequestDto.getMemberName());
+
+        return memberService.memberSignUp(memberSignupRequestDto);
+    }
+}

--- a/src/main/java/com/example/zzapdiz/member/domain/Member.java
+++ b/src/main/java/com/example/zzapdiz/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.example.zzapdiz.member.domain;
 
+import com.example.zzapdiz.share.Timestamped;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import java.util.List;
 @Builder
 @Getter
 @Entity
-public class Member {
+public class Member extends Timestamped {
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
@@ -28,6 +29,9 @@ public class Member {
 
     @Column(nullable = false)
     private String memberName;
+
+    @Column(nullable = false)
+    private int point;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @Builder.Default

--- a/src/main/java/com/example/zzapdiz/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/zzapdiz/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.example.zzapdiz.member.repository;
+
+
+import com.example.zzapdiz.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/example/zzapdiz/member/request/MemberSignupRequestDto.java
+++ b/src/main/java/com/example/zzapdiz/member/request/MemberSignupRequestDto.java
@@ -1,0 +1,33 @@
+package com.example.zzapdiz.member.request;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class MemberSignupRequestDto {
+
+    @NotBlank(message = "아이디는 공백을 포함할 수 없습니다.")
+    @Email(regexp = "^[a-zA-Z0-9]+@[a-zA-Z]+.[a-z]+${4,12}$", message = "이메일 형식에 맞지 않습니다.")
+    private String email;
+
+    @NotNull(message = "비밀번호는 공백일 수 없습니다.")
+    @Pattern(regexp="(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{7,20}",
+            message = "비밀번호는 영어 대/소문자, 숫자, 특수기호가 최소한 1개씩은 포함이 되어있어야 하며, 7~20글자 이내여야 합니다.")
+    private String password;
+
+    @NotNull(message = "비밀번호는 공백일 수 없습니다.")
+    private String passwordRecheck;
+
+    @NotBlank(message = "이름은 공백을 포함할 수 없습니다.")
+    @Size(max = 20, min = 4, message = "알맞은 길이의 닉네임이 아닙니다.")
+    private String memberName;
+
+}

--- a/src/main/java/com/example/zzapdiz/member/response/MemberSignupResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/member/response/MemberSignupResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.zzapdiz.member.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class MemberSignupResponseDto {
+    private String email;
+    private String password;
+    private String memberName;
+    private int point;
+}

--- a/src/main/java/com/example/zzapdiz/member/service/MemberService.java
+++ b/src/main/java/com/example/zzapdiz/member/service/MemberService.java
@@ -1,0 +1,44 @@
+package com.example.zzapdiz.member.service;
+
+import com.example.zzapdiz.exception.MemberExceptionInterface;
+import com.example.zzapdiz.member.domain.Member;
+import com.example.zzapdiz.member.repository.MemberRepository;
+import com.example.zzapdiz.member.request.MemberSignupRequestDto;
+import com.example.zzapdiz.share.ResponseBody;
+import com.example.zzapdiz.share.StatusCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final MemberExceptionInterface memberExceptionInterface;
+
+    // 회원가입
+    public ResponseEntity<ResponseBody> memberSignUp(MemberSignupRequestDto memberSignupRequestDto) {
+
+        // 회원가입 시 발생할 에러 처리
+        memberExceptionInterface.matchPassword(memberSignupRequestDto.getPassword(), memberSignupRequestDto.getPasswordRecheck());
+        memberExceptionInterface.alreadyExistMember(memberSignupRequestDto.getEmail());
+        memberExceptionInterface.allRequestDataCheck(memberSignupRequestDto);
+
+        // 회원가입 정보 입력
+        Member member = Member.builder()
+                .memberName(memberSignupRequestDto.getMemberName())
+                .email(memberSignupRequestDto.getEmail())
+                .password(passwordEncoder.encode(memberSignupRequestDto.getPassword()))
+                .point(0)
+                .build();
+
+        // 회원가입
+        memberRepository.save(member);
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, "회원 가입이 완료되셨습니다. 어서오세요! ^^"), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/zzapdiz/share/DynamicQueryDsl.java
+++ b/src/main/java/com/example/zzapdiz/share/DynamicQueryDsl.java
@@ -1,0 +1,35 @@
+package com.example.zzapdiz.share;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class DynamicQueryDsl {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    // 게임방 조회
+//    public List<GameRoom> findGameRooms(String condition) {
+//        return jpaQueryFactory
+//                .selectFrom(gameRoom)
+//                .where(eqMode(condition))
+//                .orderBy(gameRoom.createdAt.desc())
+//                .fetch();
+//    }
+//
+//    private BooleanExpression eqMode(String condition) {
+//        if(condition.equals("normal")){
+//            return gameRoom.mode.eq(Mode.일반);
+//        }else if(condition.equals("fool")){
+//            return gameRoom.mode.eq(Mode.바보);
+//        }else if(condition.equals("wait")){
+//            return gameRoom.status.eq("wait");
+//        }else if(condition.equals("start")){
+//            return gameRoom.status.eq("start");
+//        }
+//        return null;
+//    }
+
+}

--- a/src/main/java/com/example/zzapdiz/share/ResponseBody.java
+++ b/src/main/java/com/example/zzapdiz/share/ResponseBody.java
@@ -1,0 +1,17 @@
+package com.example.zzapdiz.share;
+
+import lombok.Getter;
+
+@Getter
+public class ResponseBody <T>{
+
+    private final int statusCode;
+    private final String statusMessage;
+    private final T data;
+
+    public ResponseBody(StatusCode statusCode, T data){
+        this.statusCode = statusCode.getStatusCode();
+        this.statusMessage = statusCode.getStatusMessage();
+        this.data = data;
+    }
+}

--- a/src/main/java/com/example/zzapdiz/share/StatusCode.java
+++ b/src/main/java/com/example/zzapdiz/share/StatusCode.java
@@ -1,0 +1,33 @@
+package com.example.zzapdiz.share;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public enum StatusCode {
+
+    // 정상 응답
+    OK(200, "정상 처리"),
+
+
+    // 잘못된 요청으로 인한 응답 (클라이언트 입장)
+    NOT_MATCH_PASSWORD(452, "비밀번호와 재확인 비밀번호가 일치하지 않습니다."),
+    ALREADY_EXIST_MEMBER(453, "이미 존재하는 이메일 계정입니다."),
+    EXIST_INCORRECTABLE_DATA(454, "회원가입 정보가 옳바르지 않습니다.");
+
+
+    // 잘못된 서버 응답 (서버 입장)
+
+    private int statusCode;
+    private String statusMessage;
+
+    public int getStatusCode(){
+        return statusCode;
+    }
+
+    public String getStatusMessage(){
+        return statusMessage;
+    }
+}

--- a/src/main/java/com/example/zzapdiz/share/Timestamped.java
+++ b/src/main/java/com/example/zzapdiz/share/Timestamped.java
@@ -1,0 +1,31 @@
+package com.example.zzapdiz.share;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Timestamped {
+
+  @JsonFormat(timezone = "Asia/Seoul")
+  @CreatedDate
+  private LocalDateTime createdAt;
+
+  @JsonFormat(timezone = "Asia/Seoul")
+  @LastModifiedDate
+  private LocalDateTime modifiedAt;
+
+}

--- a/src/test/java/com/example/zzapdiz/member/MemberConrollerTest.java
+++ b/src/test/java/com/example/zzapdiz/member/MemberConrollerTest.java
@@ -1,0 +1,92 @@
+package com.example.zzapdiz.member;
+
+import com.example.zzapdiz.member.controller.MemberController;
+import com.example.zzapdiz.member.domain.Member;
+import com.example.zzapdiz.member.request.MemberSignupRequestDto;
+import com.example.zzapdiz.member.response.MemberSignupResponseDto;
+import com.example.zzapdiz.member.service.MemberService;
+import com.example.zzapdiz.share.ResponseBody;
+import com.example.zzapdiz.share.StatusCode;
+import com.google.gson.Gson;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberConrollerTest {
+
+    @InjectMocks
+    private MemberController memberController;
+
+    @Mock
+    private MemberService memberService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void init(){
+        mockMvc = MockMvcBuilders.standaloneSetup(memberController).build();
+    }
+
+    @DisplayName("[MemberController] 회원가입 api")
+    @Test
+    void memberSignUpTest() throws Exception{
+        // given
+        MemberSignupRequestDto memberSignupRequestDto = MemberSignupRequestDto.builder()
+                .email("wlstpgns51@naver.com")
+                .memberName("진세훈")
+                .password("wls124578!")
+                .passwordRecheck("wls124578!")
+                .build();
+
+        MemberSignupResponseDto memberSignupResponseDto = MemberSignupResponseDto.builder()
+                .email("wlstpgns51@naver.com")
+                .password("wls124578!")
+                .memberName("진세훈")
+                .point(0)
+                .build();
+
+        doReturn(new ResponseEntity<>(new ResponseBody(StatusCode.OK, memberSignupResponseDto), HttpStatus.OK))
+                .when(memberService)
+                .memberSignUp(any(MemberSignupRequestDto.class));
+
+        String memberSinupInfo = new Gson().toJson(memberSignupRequestDto);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post("/zzapdiz/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(memberSinupInfo))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.email").value(memberSignupRequestDto.getEmail()))
+                .andExpect(jsonPath("$.data.memberName").value(memberSignupRequestDto.getMemberName()));
+
+        // then
+//        MvcResult mvcResult = (MvcResult) resultActions
+//                .andDo(print())
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.data.email").value(memberSignupRequestDto.getEmail()))
+//                .andExpect(jsonPath("$.data.memberName").value(memberSignupRequestDto.getMemberName()));
+
+    }
+}

--- a/src/test/java/com/example/zzapdiz/member/MemberServiceTest.java
+++ b/src/test/java/com/example/zzapdiz/member/MemberServiceTest.java
@@ -1,0 +1,63 @@
+package com.example.zzapdiz.member;
+
+import com.example.zzapdiz.exception.MemberExceptionInterface;
+import com.example.zzapdiz.member.domain.Member;
+import com.example.zzapdiz.member.repository.MemberRepository;
+import com.example.zzapdiz.member.request.MemberSignupRequestDto;
+import com.example.zzapdiz.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private MemberExceptionInterface memberExceptionInterface;
+
+
+    @DisplayName("[MemberService] 회원가입 서비스")
+    @Test
+    void memberSignUpServiceTest() {
+        // given
+        MemberSignupRequestDto memberSignupRequestDto = MemberSignupRequestDto.builder()
+                .email("wlstpgns51@naver.com")
+                .memberName("진세훈")
+                .password("wls124578!")
+                .passwordRecheck("wls124578!")
+                .build();
+
+        // 의존 주입받은 회원가입 에러 처리 인터페이스
+        memberExceptionInterface.matchPassword(memberSignupRequestDto.getPassword(), memberSignupRequestDto.getPasswordRecheck());
+        memberExceptionInterface.alreadyExistMember(memberSignupRequestDto.getEmail());
+        memberExceptionInterface.allRequestDataCheck(memberSignupRequestDto);
+
+//        given(memberRepository.save(any()));
+
+        // when
+        int statusCode = memberService.memberSignUp(memberSignupRequestDto).getBody().getStatusCode();
+
+        System.out.println("서비스 테스트 ");
+
+        // then
+        assertThat(statusCode).isEqualTo(200);
+//        verify(memberRepository).save(createMember);
+    }
+
+}


### PR DESCRIPTION
Feature/Member/Signup
- MemberController 회원가입 api 1차 완성
- MemberService 회원가입 Service 1차 완성
- Member 엔티티 생성
- MemberRepository 생성
- 회원가입을 위한 요청 객체 MemberSignupRequestDto 생성
- 테스트 코드 응답을 위한 MemberSignupResponseDto 객체 생성
- Member 전용 에러 처리 및 확인을 위한 MemberException 인터페이스 생성
- SecurityConfig 에서 회원가입 권한 허용
- MemberController 테스트 코드 작성 (회원가입 api 테스트)
- MemberService 테스트 코드 작성 (회원가입 서비스 비즈니스 로직 테스트)
- ResponseEntity로 반환받을 시 제네릭 타입으로 반환값의 범위를 넓혀주기 위한 ResponseBody 객체 생성
- 정상 처리, 서버 오류, 클라이언트 오류와 같은 상태를 확인하기 위한 커스텀 StatusCode 객체 생성
- 엔티티 생성 시 자동적으로 생성일자와 변경일자를 반영하기 위한 TimeStamped 객체 생성