### PR TITLE
아이디 찾기 api  1차 구현 도중 보류

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,10 @@ dependencies {
     // gson (테스트 코드 작성할 때 반환 받을 정보를 객체 타입이 아닌 문자열 타입으로 받기 위함.)
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
 
+    // email을 보내기 위한 dependency
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/zzapdiz/configuration/MailConfig.java
+++ b/src/main/java/com/example/zzapdiz/configuration/MailConfig.java
@@ -1,0 +1,40 @@
+//package com.example.zzapdiz.configuration;
+//
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.mail.javamail.JavaMailSender;
+//import org.springframework.mail.javamail.JavaMailSenderImpl;
+//
+//import java.util.Properties;
+//
+//@Configuration
+//public class MailConfig {
+//
+//    // host, username, password, port, ssl.trust
+//
+//    @Bean
+//    public JavaMailSender javaMailService() {
+//        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+//
+//        javaMailSender.setHost("smtp.naver.com");
+//        javaMailSender.setUsername("네이버 SMTP 설정 이메일");
+//        javaMailSender.setPassword("네이버 계정 비밀번호");
+//        javaMailSender.setPort(465);
+//        javaMailSender.setJavaMailProperties(getMailProperties());
+//
+//        return javaMailSender;
+//    }
+//
+//    /** 메일을 보내기 위한 smtp 설정 **/
+//    private Properties getMailProperties() {
+//        Properties properties = new Properties();
+//        properties.setProperty("mail.transport.protocol", "smtp");
+//        properties.setProperty("mail.smtp.auth", "true");
+//        properties.setProperty("mail.smtp.starttls.enable", "true");
+//        properties.setProperty("mail.debug", "true");
+//        properties.setProperty("mail.smtp.ssl.trust","smtp.naver.com");
+//        properties.setProperty("mail.smtp.ssl.enable","true");
+//
+//        return properties;
+//    }
+//}

--- a/src/main/java/com/example/zzapdiz/configuration/SecurityConfig.java
+++ b/src/main/java/com/example/zzapdiz/configuration/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
                         "/css/**",
                         "/assets/**").permitAll()
                 .antMatchers("/zzapdiz/member/signup",
-                        "/zzapdiz/member/login").permitAll()
+                        "/zzapdiz/member/login",
+                        "/zzapdiz/member/findid").permitAll()
                 .antMatchers("/test").hasRole("USER")
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/com/example/zzapdiz/member/controller/MemberController.java
+++ b/src/main/java/com/example/zzapdiz/member/controller/MemberController.java
@@ -3,9 +3,11 @@ package com.example.zzapdiz.member.controller;
 import com.example.zzapdiz.member.request.MemberLoginRequestDto;
 import com.example.zzapdiz.member.request.MemberSignupRequestDto;
 import com.example.zzapdiz.member.service.MemberService;
+import com.example.zzapdiz.share.MailDto;
 import com.example.zzapdiz.share.ResponseBody;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,9 +32,19 @@ public class MemberController {
 
     /** 로그인 **/
     @GetMapping("/member/login")
-    private ResponseEntity<ResponseBody> memberLogin(HttpServletResponse response, @RequestBody MemberLoginRequestDto memberLoginRequestDto){
+    public ResponseEntity<ResponseBody> memberLogin(HttpServletResponse response, @RequestBody MemberLoginRequestDto memberLoginRequestDto){
         log.info("로그인 api : 이메일 - {}, 비밀번호 - {}", memberLoginRequestDto.getEmail(), memberLoginRequestDto.getPassword());
 
         return memberService.memberLogin(response, memberLoginRequestDto);
     }
+
+    /** 아이디 찾기 (아이디 확인) **/
+    @PostMapping("/member/findid")
+    public ResponseEntity<ResponseBody> findMemberEmail(@RequestBody MailDto mailDto){
+        log.info("아이디 찾기 메일을 받을 이메일 주소 : {}",
+                mailDto.getMailAddress());
+
+        return memberService.findMemberEmail(mailDto);
+    }
+
 }

--- a/src/main/java/com/example/zzapdiz/share/MailDto.java
+++ b/src/main/java/com/example/zzapdiz/share/MailDto.java
@@ -1,0 +1,8 @@
+package com.example.zzapdiz.share;
+
+import lombok.Getter;
+
+@Getter
+public class MailDto {
+    private String mailAddress;
+}


### PR DESCRIPTION
[Feature/Member/FindId]
- MemberController 아이디 찾기 api 1차 구현
- 아이디 찾기 확인 메일 발송 비즈니스 로직 1차 구현 (구현 보류)
- SecurityConfig 아이디 찾기 api 권한 허용
- 메일 내용 MailDto 객체 생성
- 메일 관련 spring boot starter mail dependency 임포트

!! 아이디 찾기와 비밀번호 찾기는 계정 이메일에 확인용 메일을 보내는데 
현재 구글은 단순 아이디와 비밀번호로 접근할 수 있는 기능의 권한을 막아놓은 상태이고
네이버는 2단계 보안 설정을 가진 계정들은 접근을 못하게 되어있어 다른 방식으로 
구현해야 될 것 같아서 일단 보류한다.