### PR TITLE
펀딩 프로젝트 생성 1단계 api 1차 구현

### DIFF
--- a/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProejctExceptionInterface.java
+++ b/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProejctExceptionInterface.java
@@ -1,0 +1,13 @@
+package com.example.zzapdiz.exception.fundingproject;
+
+import com.example.zzapdiz.share.ResponseBody;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface FundingProejctExceptionInterface {
+
+    /** 펀딩 프로젝트 생성 마지막 최종 단계에서 반드시 기입되어야할 정보가 하나라도
+     * 명확하지 않다면 에러 응답 처리 **/
+
+}

--- a/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProjectException.java
+++ b/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProjectException.java
@@ -1,0 +1,8 @@
+package com.example.zzapdiz.exception.fundingproject;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class FundingProjectException implements  FundingProejctExceptionInterface{
+
+}

--- a/src/main/java/com/example/zzapdiz/exception/member/MemberException.java
+++ b/src/main/java/com/example/zzapdiz/exception/member/MemberException.java
@@ -96,8 +96,6 @@ public class MemberException implements MemberExceptionInterface{
     @Override
     public ResponseEntity<ResponseBody> checkHeaderToken(HttpServletRequest request) {
         if(!jwtTokenProvider.validateToken(request.getHeader("Refresh-Token"))){
-            System.out.println(request.getHeader("Authorization"));
-
             return new ResponseEntity<>(new ResponseBody(StatusCode.UNAUTHORIZED_TOKEN, null), HttpStatus.BAD_REQUEST);
         }
 

--- a/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
@@ -1,0 +1,36 @@
+package com.example.zzapdiz.fundingproject.controller;
+
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
+import com.example.zzapdiz.fundingproject.service.FundingProjectService;
+import com.example.zzapdiz.share.ResponseBody;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/zzapdiz")
+@RestController
+public class FundingProjectController {
+
+    private final FundingProjectService fundingProjectService;
+
+    /**
+     * 펀딩 프로젝트 생성 1단계
+     **/
+    @PostMapping("/funding/create/phase1")
+    public ResponseEntity<ResponseBody> fundingCreatePhase1(
+            HttpServletRequest request,
+            @RequestBody FundingProjectCreatePhase1RequestDto fundingProjectCreatePhase1RequestDto) {
+        log.info("펀딩 프로젝트 생성 1단계 api : 생성자 - {}, 프로젝트 유형 - {}", request, fundingProjectCreatePhase1RequestDto.getProjectType());
+
+        return fundingProjectService.fundingCreatePhase1(request, fundingProjectCreatePhase1RequestDto);
+    }
+
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
@@ -1,0 +1,84 @@
+package com.example.zzapdiz.fundingproject.domain;
+
+import com.example.zzapdiz.share.MakerType;
+import com.example.zzapdiz.share.ProjectCategory;
+import com.example.zzapdiz.share.ProjectType;
+import com.example.zzapdiz.share.Timestamped;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class FundingProject extends Timestamped {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long fundingProjectId;
+
+    @Column(nullable = false)
+    private String projectTitle;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ProjectCategory projectCategory;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ProjectType projectType;
+
+    @Column(nullable = false)
+    private int achievedAmount;
+
+    @Column(nullable = false)
+    private String adultCheck;
+
+    @Column(nullable = false)
+    private String searchTag;
+
+    @Column(nullable = false)
+    private String storyText;
+
+    @Column
+    private String storyImage;
+
+    @Column
+    private String storyVideo;
+
+    @Column(nullable = false)
+    private String projectDescript;
+
+    @Column(nullable = false)
+    private String openReservation;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+
+    @Column(nullable = false)
+    private String thumbnailImage;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MakerType makerType;
+
+    @Column(nullable = false)
+    private String progress;
+
+    @Column(nullable = false)
+    private String deliveryCheck;
+
+    @Column
+    private String deliveryPrice;
+
+    @Column
+    private LocalDate deliveryStartDate;
+
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/repository/FundingProjectRepository.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/repository/FundingProjectRepository.java
@@ -1,0 +1,9 @@
+package com.example.zzapdiz.fundingproject.repository;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FundingProjectRepository extends JpaRepository<FundingProject, Long> {
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/request/FundingProjectCreatePhase1RequestDto.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/request/FundingProjectCreatePhase1RequestDto.java
@@ -1,0 +1,20 @@
+package com.example.zzapdiz.fundingproject.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class FundingProjectCreatePhase1RequestDto {
+
+    private String projectCategory;
+    private String projectType;
+    private String makerType;
+    private String rewardType;
+    private String rewardMakeType;
+    private int achievedAmount;
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/response/FundingProjectCreatePhase1ResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/response/FundingProjectCreatePhase1ResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.zzapdiz.fundingproject.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class FundingProjectCreatePhase1ResponseDto {
+    private String projectCategory;
+    private String projectType;
+    private String makerType;
+    private String rewardType;
+    private String rewardMakeType;
+    private int achievedAmount;
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
@@ -1,0 +1,41 @@
+package com.example.zzapdiz.fundingproject.service;
+
+import com.example.zzapdiz.exception.member.MemberException;
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
+import com.example.zzapdiz.share.ResponseBody;
+import com.example.zzapdiz.share.StatusCode;
+import com.google.gson.Gson;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FundingProjectService {
+
+    private final MemberException memberException;
+
+    // 펀딩 프로젝트 생성 1단계
+    public ResponseEntity<ResponseBody> fundingCreatePhase1(
+            HttpServletRequest request,
+            FundingProjectCreatePhase1RequestDto fundingProjectCreatePhase1RequestDt0){
+
+        // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
+        memberException.checkHeaderToken(request);
+
+        // Request에 Phase1 생성 단계 속성 생성
+        request.setAttribute("phase1Info", fundingProjectCreatePhase1RequestDt0);
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, "펀딩 프로젝트 생성 1단계 완료!"), HttpStatus.OK);
+    }
+
+    // Gson().toJson("Json 객체 혹은 Dto 객체") -> Json 형식의 객체를 String 타입으로 변환
+    // Gson().fromJson("String 타입으로 변환된 객체", 변환될 Json 형식객체 혹은 DTO 객체.class) -> String 타입으로 변환된 Json 객체를 다시 Json 형식으로 변환
+}
+
+

--- a/src/main/java/com/example/zzapdiz/reward/Reward.java
+++ b/src/main/java/com/example/zzapdiz/reward/Reward.java
@@ -1,0 +1,38 @@
+package com.example.zzapdiz.reward;
+
+import com.example.zzapdiz.share.RewardMakeType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+public class Reward {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long rewardId;
+
+    @Column(nullable = false)
+    private String rewardType; // 리워드 유형
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private RewardMakeType rewardMakeType; // 리워드 제작 유형
+
+    @Column(nullable = false)
+    private String rewardTitle; // 리워드 명
+
+    @Column(nullable = false)
+    private int rewardAmount; // 리워드 제한 수량
+
+    @Column(nullable = false)
+    private int rewardQuantity; // 리워드 금액
+
+    @Column(nullable = false)
+    private String rewardContent; // 리워드 내용
+}

--- a/src/main/java/com/example/zzapdiz/share/MakerType.java
+++ b/src/main/java/com/example/zzapdiz/share/MakerType.java
@@ -1,0 +1,15 @@
+package com.example.zzapdiz.share;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public enum MakerType {
+
+    PERSONAL("개인"),
+    PERSONAL_BUSINESS("개인 사업자"),
+    CORPORATE_BUSINESS("법인 사업자");
+
+    private String makerType;
+}

--- a/src/main/java/com/example/zzapdiz/share/ProjectCategory.java
+++ b/src/main/java/com/example/zzapdiz/share/ProjectCategory.java
@@ -1,0 +1,21 @@
+package com.example.zzapdiz.share;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public enum ProjectCategory {
+
+    TECH("테크/가전"),
+    FOOD("푸드"),
+    HOME_LIVING("홈/리빙"),
+    SPORTS_MOBILITY("스포츠/모빌리티"),
+    CHARACTER_GOODS("캐릭터/굿즈"),
+    GAME_HOBBY("게임/취미"),
+    CULTURE_ARTIST("컬쳐/아티스트"),
+    GROUP("모임");
+
+    private String category;
+
+}

--- a/src/main/java/com/example/zzapdiz/share/ProjectType.java
+++ b/src/main/java/com/example/zzapdiz/share/ProjectType.java
@@ -1,0 +1,16 @@
+package com.example.zzapdiz.share;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public enum ProjectType {
+
+    FIRST_OPEN("첫 출시"),
+    REMAKE("기존에 출시된 제품/서비스/컨텐츠를 리메이크"),
+    BROAD_SELL("해외에서 출시된 제품 공식 유통"),
+    SUCCESSED_PROJECT_REOPEN("와디즈에서 성공한 프로젝트 다시 공유");
+
+    private String projectType;
+}

--- a/src/main/java/com/example/zzapdiz/share/RewardMakeType.java
+++ b/src/main/java/com/example/zzapdiz/share/RewardMakeType.java
@@ -1,0 +1,16 @@
+package com.example.zzapdiz.share;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public enum RewardMakeType {
+
+    SELF_MADE("직접 제조"),
+    CONSIGNMENT_MADE("위탁 제조"),
+    ODM("ODM"),
+    GLOBAL("글로벌");
+
+    private String rewardMakeType;
+}

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
@@ -1,0 +1,101 @@
+package com.example.zzapdiz.fundingproject;
+
+import com.example.zzapdiz.fundingproject.controller.FundingProjectController;
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
+import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase1ResponseDto;
+import com.example.zzapdiz.fundingproject.service.FundingProjectService;
+import com.example.zzapdiz.member.domain.Member;
+import com.example.zzapdiz.member.request.MemberSignupRequestDto;
+import com.example.zzapdiz.share.ResponseBody;
+import com.example.zzapdiz.share.StatusCode;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class FundingProjectConrollerTest {
+
+    @InjectMocks
+    private FundingProjectController fundingProjectController;
+
+    @Mock
+    private FundingProjectService fundingProjectService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void init() {
+        mockMvc = MockMvcBuilders.standaloneSetup(fundingProjectController).build();
+    }
+
+    @DisplayName("[FundingProjectController] 펀딩 프로젝트 생성 1단계 api")
+    @Test
+    void createFundingPhase1() throws Exception {
+        // given
+        doReturn(new ResponseEntity<>(new ResponseBody(StatusCode.OK, phase1ResponseDto()), HttpStatus.OK))
+                .when(fundingProjectService)
+                .fundingCreatePhase1(any(MockHttpServletRequest.class), any(FundingProjectCreatePhase1RequestDto.class));
+
+        String phase1RequestDto = new Gson().toJson(phase1RequestDto());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post("/zzapdiz/funding/create/phase1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(phase1RequestDto));
+
+        // then
+        ResultActions resultActionsThen = resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.projectCategory").value(phase1RequestDto().getProjectCategory()))
+                .andExpect(jsonPath("$.data.projectType").value(phase1RequestDto().getProjectType()))
+                .andExpect(jsonPath("$.data.makerType").value(phase1RequestDto().getMakerType()))
+                .andExpect(jsonPath("$.data.rewardType").value(phase1RequestDto().getRewardType()))
+                .andExpect(jsonPath("$.data.rewardMakeType").value(phase1RequestDto().getRewardMakeType()))
+                .andExpect(jsonPath("$.data.achievedAmount").value(phase1RequestDto().getAchievedAmount()));
+
+    }
+
+    private FundingProjectCreatePhase1RequestDto phase1RequestDto() {
+        return FundingProjectCreatePhase1RequestDto.builder()
+                .projectCategory("TECH")
+                .projectType("FIRST_OPEN")
+                .makerType("PERSONAL!")
+                .rewardType("가구/인테리어")
+                .rewardMakeType("SELF_MADE")
+                .achievedAmount(8000000)
+                .build();
+    }
+
+    private FundingProjectCreatePhase1ResponseDto phase1ResponseDto(){
+        return FundingProjectCreatePhase1ResponseDto.builder()
+                .projectCategory("TECH")
+                .projectType("FIRST_OPEN")
+                .makerType("PERSONAL!")
+                .rewardType("가구/인테리어")
+                .rewardMakeType("SELF_MADE")
+                .achievedAmount(8000000)
+                .build();
+    }
+}

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectServiceTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectServiceTest.java
@@ -1,0 +1,59 @@
+package com.example.zzapdiz.fundingproject;
+
+import com.example.zzapdiz.exception.member.MemberException;
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
+import com.example.zzapdiz.fundingproject.service.FundingProjectService;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class FundingProjectServiceTest {
+
+    @InjectMocks
+    private FundingProjectService fundingProjectService;
+
+    @Mock
+    private MemberException memberException;
+
+    @DisplayName("[FundingProjectService] 펀딩 프로젝트 생성 1단계 서비스")
+    @Test
+    void createFundingPhase1() {
+        // given
+        MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+
+        // when
+        int statusCode = fundingProjectService.fundingCreatePhase1(
+                mockHttpServletRequest,
+                phase1RequestDto()).getBody().getStatusCode();
+
+        String phase1Info = new Gson().toJson(mockHttpServletRequest.getAttribute("phase1Info"));
+        FundingProjectCreatePhase1RequestDto fundingProjectCreatePhase1RequestDto =
+                new Gson().fromJson(phase1Info, FundingProjectCreatePhase1RequestDto.class);
+
+        // then
+        assertThat(statusCode).isEqualTo(200);
+        assertThat(fundingProjectCreatePhase1RequestDto.getProjectType()).isEqualTo(phase1RequestDto().getProjectType());
+    }
+
+    private FundingProjectCreatePhase1RequestDto phase1RequestDto(){
+        return FundingProjectCreatePhase1RequestDto.builder()
+                .projectCategory("TECH")
+                .projectType("FIRST_OPEN")
+                .makerType("PERSONAL!")
+                .rewardType("가구/인테리어")
+                .rewardMakeType("SELF_MADE")
+                .achievedAmount(8000000)
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/zzapdiz/member/MemberServiceTest.java
+++ b/src/test/java/com/example/zzapdiz/member/MemberServiceTest.java
@@ -19,7 +19,6 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.servlet.ServletException;


### PR DESCRIPTION
[Feature/Funding/Create/Phase1]
- FundingProject 펀딩 프로젝트 엔티티 생성
- FundingProjectController 펀딩 프로젝트 생성 관련 컨트롤러 생성
- FundingProject 생성 1단계 api 1차 구현
- Jpa 사용을 위한 FundingProjectRepository 생성
- 펀딩 프로젝트 생성 1단계 정보 요청을 위한 FundingProjectCreatePhase1RequestDto 생성
- 테스트 및 포스트맨으로 확인을 위한 FundingProjectCreatePhase1ResponseDto 생성
- 펀딩 프로젝트 생성 1단계 비즈니스 로직을 위한 FundingProjectService 생성
- 펀딩 프로젝트 포함되는 리워드를 위한 Reward 엔티티 생성
- 제작 유형, 프로젝트 카테고리, 프로젝트 유형, 리워드 제작 유형은 Enum 타입 객체로 구현
- 1단계 정보들을 바로 FundingProject 엔티티에 저장하는 것이 아닌 임시저장하기 위해 HttpServletRequest에 Attribute를 생성하여 저장
- 펀딩 프로젝트 컨트롤러, 서비스 테스트를 위한 테스트 코드 작성