### PR TITLE
펀딩 프로젝트 생성 2단계 api 1차 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,8 @@ dependencies {
     // email을 보내기 위한 dependency
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
-
+    // spring boot session - session 데이터를 관리하기 위한 dependency (펀딩 프로젝트 단계별 정보들 관리)
+    implementation 'org.springframework.session:spring-session-core'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProejctExceptionInterface.java
+++ b/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProejctExceptionInterface.java
@@ -1,11 +1,16 @@
 package com.example.zzapdiz.exception.fundingproject;
 
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
 import com.example.zzapdiz.share.ResponseBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 @Component
 public interface FundingProejctExceptionInterface {
+
+    /** 생성한 펀딩 프로젝트 2단계 정보 확인 **/
+    ResponseEntity<ResponseBody> checkPhase2Info(FundingProjectCreatePhase2RequestDto fundingProjectCreatePhase2RequestDto, MultipartFile thumbnailImage);
 
     /** 펀딩 프로젝트 생성 마지막 최종 단계에서 반드시 기입되어야할 정보가 하나라도
      * 명확하지 않다면 에러 응답 처리 **/

--- a/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProjectException.java
+++ b/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProjectException.java
@@ -1,8 +1,25 @@
 package com.example.zzapdiz.exception.fundingproject;
 
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
+import com.example.zzapdiz.share.ResponseBody;
+import com.example.zzapdiz.share.StatusCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 @Component
 public class FundingProjectException implements  FundingProejctExceptionInterface{
 
+    @Override
+    public ResponseEntity<ResponseBody> checkPhase2Info(FundingProjectCreatePhase2RequestDto fundingProjectCreatePhase2RequestDto, MultipartFile thumbnailImage) {
+        if(fundingProjectCreatePhase2RequestDto.getProjectTitle() == null ||
+        fundingProjectCreatePhase2RequestDto.getAdultCheck() == null ||
+        fundingProjectCreatePhase2RequestDto.getEndDate() == null ||
+        fundingProjectCreatePhase2RequestDto.getSearchTag() == null ||
+        thumbnailImage == null){
+            return new ResponseEntity<>(new ResponseBody(StatusCode.EXIST_INCORRECTABLE_FUNDING_INFO, null), HttpStatus.BAD_REQUEST);
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
@@ -1,15 +1,15 @@
 package com.example.zzapdiz.fundingproject.controller;
 
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
 import com.example.zzapdiz.fundingproject.service.FundingProjectService;
 import com.example.zzapdiz.share.ResponseBody;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -21,16 +21,25 @@ public class FundingProjectController {
 
     private final FundingProjectService fundingProjectService;
 
-    /**
-     * 펀딩 프로젝트 생성 1단계
-     **/
+    /** 펀딩 프로젝트 생성 1단계 **/
     @PostMapping("/funding/create/phase1")
     public ResponseEntity<ResponseBody> fundingCreatePhase1(
             HttpServletRequest request,
             @RequestBody FundingProjectCreatePhase1RequestDto fundingProjectCreatePhase1RequestDto) {
-        log.info("펀딩 프로젝트 생성 1단계 api : 생성자 - {}, 프로젝트 유형 - {}", request, fundingProjectCreatePhase1RequestDto.getProjectType());
+        log.info("펀딩 프로젝트 생성 1단계 api : 생성자 - {}, 프로젝트 유형 확인 - {}", request, fundingProjectCreatePhase1RequestDto.getProjectType());
 
         return fundingProjectService.fundingCreatePhase1(request, fundingProjectCreatePhase1RequestDto);
+    }
+
+    /** 펀딩 프로젝트 생성 2단계 **/
+    @PostMapping(value = "/funding/create/phase2", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE}, produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<ResponseBody> fundingCreatePhase2(
+            HttpServletRequest request,
+            @RequestPart(value="phase2Request", required = false) FundingProjectCreatePhase2RequestDto fundingProjectCreatePhase2RequestDto,
+            @RequestPart(value="thumbnailImage", required = false) MultipartFile thumbnailImage){
+        log.info("펀딩 프로젝트 생성 2단계 api : 생성자 - {}, 프로젝트 타이틀 확인 - {}", request, fundingProjectCreatePhase2RequestDto.getProjectTitle());
+
+        return fundingProjectService.fundingCreatePhase2(request, fundingProjectCreatePhase2RequestDto, thumbnailImage);
     }
 
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/request/FundingProjectCreatePhase2RequestDto.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/request/FundingProjectCreatePhase2RequestDto.java
@@ -1,0 +1,20 @@
+package com.example.zzapdiz.fundingproject.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class FundingProjectCreatePhase2RequestDto {
+
+    private String projectTitle;
+    private String endDate;
+    private String adultCheck;
+    private String searchTag;
+
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/response/FundingProjectCreatePhase2ResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/response/FundingProjectCreatePhase2ResponseDto.java
@@ -5,10 +5,11 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.Serializable;
+import java.time.LocalDateTime;
 
-//@ToString
 @AllArgsConstructor
 @NoArgsConstructor
 @Component
@@ -16,13 +17,10 @@ import java.io.Serializable;
 @Builder
 @Setter
 @Getter
-public class FundingProjectCreatePhase1ResponseDto implements Serializable {
-    // Serializable 을 implements 한 이유 : 이후에 redis에 임시저장하려면 직렬화가 되어있어야 하기 때문이다.
-
-    private String projectCategory;
-    private String projectType;
-    private String makerType;
-    private String rewardType;
-    private String rewardMakeType;
-    private int achievedAmount;
+public class FundingProjectCreatePhase2ResponseDto implements Serializable {
+    private String projectTitle;
+    private MultipartFile thumbnailImage;
+    private String endDate;
+    private String adultCheck;
+    private String searchTag;
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
@@ -1,17 +1,29 @@
 package com.example.zzapdiz.fundingproject.service;
 
+import com.example.zzapdiz.exception.fundingproject.FundingProjectException;
 import com.example.zzapdiz.exception.member.MemberException;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
+import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase1ResponseDto;
+import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase2ResponseDto;
 import com.example.zzapdiz.share.ResponseBody;
 import com.example.zzapdiz.share.StatusCode;
-import com.google.gson.Gson;
+import com.google.gson.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -19,6 +31,10 @@ import javax.servlet.http.HttpServletRequest;
 public class FundingProjectService {
 
     private final MemberException memberException;
+    private final FundingProjectException fundingProjectException;
+    private final FundingProjectCreatePhase1ResponseDto fundingProjectCreatePhase1ResponseDto;
+    private final FundingProjectCreatePhase2ResponseDto fundingProjectCreatePhase2ResponseDto;
+
 
     // 펀딩 프로젝트 생성 1단계
     public ResponseEntity<ResponseBody> fundingCreatePhase1(
@@ -28,14 +44,72 @@ public class FundingProjectService {
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
         memberException.checkHeaderToken(request);
 
-        // Request에 Phase1 생성 단계 속성 생성
-        request.setAttribute("phase1Info", fundingProjectCreatePhase1RequestDt0);
+        // spring scope bean 을 사용하여 1단계 생성 정보들을 session으로 어플리케이션 내부에 임시저장
+        // scale out 해서 이후에 서버를 증설한다면 redis로 이전할 필요가 있음
+        fundingProjectCreatePhase1ResponseDto.setProjectCategory(fundingProjectCreatePhase1RequestDt0.getProjectCategory());
+        fundingProjectCreatePhase1ResponseDto.setProjectType(fundingProjectCreatePhase1RequestDt0.getProjectType());
+        fundingProjectCreatePhase1ResponseDto.setMakerType(fundingProjectCreatePhase1RequestDt0.getMakerType());
+        fundingProjectCreatePhase1ResponseDto.setRewardType(fundingProjectCreatePhase1RequestDt0.getRewardType());
+        fundingProjectCreatePhase1ResponseDto.setRewardMakeType(fundingProjectCreatePhase1RequestDt0.getRewardMakeType());
+        fundingProjectCreatePhase1ResponseDto.setAchievedAmount(fundingProjectCreatePhase1RequestDt0.getAchievedAmount());
 
         return new ResponseEntity<>(new ResponseBody(StatusCode.OK, "펀딩 프로젝트 생성 1단계 완료!"), HttpStatus.OK);
     }
 
+
+    // 펀딩 프로젝트 생성 2단계
+    public ResponseEntity<ResponseBody> fundingCreatePhase2(
+            HttpServletRequest request,
+            FundingProjectCreatePhase2RequestDto fundingProjectCreatePhase2RequestDto,
+            MultipartFile thumbnailImage){
+
+        // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
+        memberException.checkHeaderToken(request);
+        // 2단계 정보 확인
+        fundingProjectException.checkPhase2Info(fundingProjectCreatePhase2RequestDto, thumbnailImage);
+
+        // sprin scope bean 을 사용하여 2단계 생성 정보들을 session으로 어플리케이션 내부에 저장 및 관리
+        fundingProjectCreatePhase2ResponseDto.setProjectTitle(fundingProjectCreatePhase2RequestDto.getProjectTitle());
+        fundingProjectCreatePhase2ResponseDto.setThumbnailImage(thumbnailImage);
+        fundingProjectCreatePhase2ResponseDto.setEndDate(fundingProjectCreatePhase2RequestDto.getEndDate());
+        fundingProjectCreatePhase2ResponseDto.setAdultCheck(fundingProjectCreatePhase2RequestDto.getAdultCheck());
+        fundingProjectCreatePhase2ResponseDto.setSearchTag(fundingProjectCreatePhase2RequestDto.getSearchTag());
+
+        HashMap<String, Object> resultSet = new HashMap<>();
+        resultSet.put("phase2CreateMessage", "펀딩 프로젝트 생성 2단계 완료!");
+        resultSet.put("phase2ResponseInfo", fundingProjectCreatePhase2ResponseDto);
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, resultSet), HttpStatus.OK);
+    }
+
     // Gson().toJson("Json 객체 혹은 Dto 객체") -> Json 형식의 객체를 String 타입으로 변환
     // Gson().fromJson("String 타입으로 변환된 객체", 변환될 Json 형식객체 혹은 DTO 객체.class) -> String 타입으로 변환된 Json 객체를 다시 Json 형식으로 변환
+
+    // GSON에서 LocalDate 유형의 데이터를 String 타입으로 변환하기 위한 설정
+    private Gson gsonConverterFactory() {
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(LocalDateTime.class, new JsonDeserializer<LocalDateTime>() {
+                    @Override
+                    public LocalDateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+                        return LocalDateTime.parse(json.getAsString(), DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+                    }
+                })
+                .registerTypeAdapter(LocalDate.class, new JsonDeserializer<LocalDate>() {
+                    @Override
+                    public LocalDate deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+                        return LocalDate.parse(json.getAsString(), DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                    }
+                })
+                .registerTypeAdapter(LocalTime.class, new JsonDeserializer<LocalTime>() {
+                    @Override
+                    public LocalTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+                        return LocalTime.parse(json.getAsString(), DateTimeFormatter.ofPattern("HH:mm:ss"));
+                    }
+                })
+                .create();
+
+        return gson;
+    }
 }
 
 

--- a/src/main/java/com/example/zzapdiz/share/StatusCode.java
+++ b/src/main/java/com/example/zzapdiz/share/StatusCode.java
@@ -19,7 +19,8 @@ public enum StatusCode {
     NOT_FOUND_MATCHING_EMAIL(455, "입력한 이메일에 맞는 계정 정보가 존재하지 않습니다."),
     DUPLICATED_ACCOUNT(456, "이미 회원가입된 이메일 계정입니다."),
     NOT_FOUND_MATCHING_PASSWORD(457, "비밀번호가 일치하지 않습니다."),
-    UNAUTHORIZED_TOKEN(458, "유효한 토큰이 아닙니다.");
+    UNAUTHORIZED_TOKEN(458, "유효한 토큰이 아닙니다."),
+    EXIST_INCORRECTABLE_FUNDING_INFO(459, "펀딩 프로젝트 생성 기입 정보가 올바르지 않습니다.");
 
 
 

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
@@ -2,7 +2,9 @@ package com.example.zzapdiz.fundingproject;
 
 import com.example.zzapdiz.fundingproject.controller.FundingProjectController;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
 import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase1ResponseDto;
+import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase2ResponseDto;
 import com.example.zzapdiz.fundingproject.service.FundingProjectService;
 import com.example.zzapdiz.member.domain.Member;
 import com.example.zzapdiz.member.request.MemberSignupRequestDto;
@@ -20,10 +22,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.multipart.MultipartFile;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -77,6 +81,33 @@ public class FundingProjectConrollerTest {
 
     }
 
+    @DisplayName("[FundingProjectController] 펀딩 프로젝트 생성 2단계 api")
+    @Test
+    void createFundingPhase2() throws Exception {
+        // given
+        doReturn(new ResponseEntity<>(new ResponseBody(StatusCode.OK, phase2ResponseDto()), HttpStatus.OK))
+                .when(fundingProjectService)
+                .fundingCreatePhase2(any(MockHttpServletRequest.class), any(FundingProjectCreatePhase2RequestDto.class), any(MockMultipartFile.class));
+
+        System.out.println(phase2RequestDto().getProjectTitle());
+
+        String phase2RequestDto = new Gson().toJson(phase2RequestDto());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post("/zzapdiz/funding/create/phase2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding("utf-8")
+                        .content(phase2RequestDto));
+        // then
+        ResultActions resultActionsThen = resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.projectTitle").value(phase2RequestDto().getProjectTitle()));
+
+    }
+
     private FundingProjectCreatePhase1RequestDto phase1RequestDto() {
         return FundingProjectCreatePhase1RequestDto.builder()
                 .projectCategory("TECH")
@@ -96,6 +127,24 @@ public class FundingProjectConrollerTest {
                 .rewardType("가구/인테리어")
                 .rewardMakeType("SELF_MADE")
                 .achievedAmount(8000000)
+                .build();
+    }
+
+    private FundingProjectCreatePhase2RequestDto phase2RequestDto() {
+        return FundingProjectCreatePhase2RequestDto.builder()
+                .projectTitle("생성 2단계 프로젝트 타이틀")
+                .endDate("20230314")
+                .adultCheck("O")
+                .searchTag("#검색태그1-#검색태그2")
+                .build();
+    }
+
+    private FundingProjectCreatePhase2ResponseDto phase2ResponseDto(){
+        return FundingProjectCreatePhase2ResponseDto.builder()
+                .projectTitle("생성 2단계 프로젝트 타이틀")
+                .endDate("20230314")
+                .adultCheck("O")
+                .searchTag("#검색태그1-#검색태그2")
                 .build();
     }
 }

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectServiceTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectServiceTest.java
@@ -2,6 +2,8 @@ package com.example.zzapdiz.fundingproject;
 
 import com.example.zzapdiz.exception.member.MemberException;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
+import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase2ResponseDto;
 import com.example.zzapdiz.fundingproject.service.FundingProjectService;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.DisplayName;
@@ -10,7 +12,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.web.JsonPath;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockMultipartFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -24,6 +28,9 @@ public class FundingProjectServiceTest {
 
     @Mock
     private MemberException memberException;
+
+    @Mock
+    private FundingProjectCreatePhase2ResponseDto fundingProjectCreatePhase2ResponseDto;
 
     @DisplayName("[FundingProjectService] 펀딩 프로젝트 생성 1단계 서비스")
     @Test
@@ -45,6 +52,22 @@ public class FundingProjectServiceTest {
         assertThat(fundingProjectCreatePhase1RequestDto.getProjectType()).isEqualTo(phase1RequestDto().getProjectType());
     }
 
+    @DisplayName("[FundingProjectService] 펀딩 프로젝트 생성 2단계 서비스")
+    @Test
+    void createFundingPhase2() {
+        // given
+        MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+
+        // when
+        int statusCode = fundingProjectService.fundingCreatePhase2(
+                mockHttpServletRequest,
+                phase2RequestDto(),
+                any(MockMultipartFile.class)).getBody().getStatusCode();
+
+        // then
+        assertThat(statusCode).isEqualTo(200);
+    }
+
     private FundingProjectCreatePhase1RequestDto phase1RequestDto(){
         return FundingProjectCreatePhase1RequestDto.builder()
                 .projectCategory("TECH")
@@ -53,6 +76,24 @@ public class FundingProjectServiceTest {
                 .rewardType("가구/인테리어")
                 .rewardMakeType("SELF_MADE")
                 .achievedAmount(8000000)
+                .build();
+    }
+
+    private FundingProjectCreatePhase2RequestDto phase2RequestDto(){
+        return FundingProjectCreatePhase2RequestDto.builder()
+                .projectTitle("생성 2단계 프로젝트 타이틀")
+                .endDate("20230314")
+                .adultCheck("O")
+                .searchTag("#검색태그1-#검색태그2")
+                .build();
+    }
+
+    private FundingProjectCreatePhase2ResponseDto phase2ResponseDto(){
+        return FundingProjectCreatePhase2ResponseDto.builder()
+                .projectTitle("생성 2단계 프로젝트 타이틀")
+                .endDate("20230314")
+                .adultCheck("O")
+                .searchTag("#검색태그1-#검색태그2")
                 .build();
     }
 


### PR DESCRIPTION
[Feature/Funding/Create/Phase2]
- FundingProjectController 펀딩 프로젝트 2단계 생성 api 1차 구현
- FundingProjectService 펀딩 프로젝트 2단계 생성 비즈니스 로직 구성
- 단계마다 기입한 정보들을 기존에는 Servlet에 setAttribute로 임시저장하여 다음 단계로 넘기는 방법에서 Spring Scope Bean을 통해 session으로 내부 어플리케이션에 임시저장하면서 유지 시키는 방법으로 변경
- 펀딩 프로젝트 2단계 정보 기입 요청을 위한 FundingProjectCreatePhase2RequestDto 객체 생성
- 테스트 및 결과 확인을 위한 FundingProjectCreatePhase2ResponseDto 객체 생성
- ThumbnailImage(대표 이미지)의 경우 MultiPartFile 형식으로 RequestDto에 한번에 받지 않고 따로 RequestPart로 구분하여 받음.
- 펀딩 프로젝트 2단계 생성 시 발생할 수 있는 에러 처리 Exception 추가
- FundingProjectControllerTest, FundingProjectServiceTest 업데이트
- MultiPartFile 용량 application.properties에서 관리
- 펀딩 프로젝트 정보들을 임시저장하는 session 유지 시간 application.propertiest 에서 관리