### PR TITLE
펀딩 프로젝트 3단계 생성 api 1차 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 application.properties
+application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'junit:junit:4.13.1'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -57,6 +58,15 @@ dependencies {
 
     // spring boot session - session 데이터를 관리하기 위한 dependency (펀딩 프로젝트 단계별 정보들 관리)
     implementation 'org.springframework.session:spring-session-core'
+
+    // Redis 의존성 dependency
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
+
+    // Aws dependency
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/zzapdiz/ZzapdizApplication.java
+++ b/src/main/java/com/example/zzapdiz/ZzapdizApplication.java
@@ -3,6 +3,7 @@ package com.example.zzapdiz;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/com/example/zzapdiz/configuration/AwsS3Config.java
+++ b/src/main/java/com/example/zzapdiz/configuration/AwsS3Config.java
@@ -1,0 +1,35 @@
+package com.example.zzapdiz.configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    // S3를 등록한 사람이 전달받은 접속하기 위한 key 값
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    // S3를 등록한 사람이 전달받은 접속하기 위한 secret key 값
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    // S3를 등록한 사람이 S3를 사용할 지역
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    // 전달받은 Accesskey 와 SecretKey 로 아마존 서비스 실행 준비
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .build();
+    }
+}

--- a/src/main/java/com/example/zzapdiz/configuration/RedisConfig.java
+++ b/src/main/java/com/example/zzapdiz/configuration/RedisConfig.java
@@ -1,0 +1,46 @@
+package com.example.zzapdiz.configuration;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(redisHost,redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<?,?> redisTemplate(){
+        RedisTemplate<byte[], byte[]> redisTemplate=new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+//        redisTemplate.setKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(){
+        StringRedisTemplate stringRedisTemplate=new StringRedisTemplate();
+        stringRedisTemplate.setKeySerializer(new StringRedisSerializer());
+        stringRedisTemplate.setValueSerializer(new StringRedisSerializer());
+        stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+        return stringRedisTemplate;
+    }
+}

--- a/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProejctExceptionInterface.java
+++ b/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProejctExceptionInterface.java
@@ -1,16 +1,27 @@
 package com.example.zzapdiz.exception.fundingproject;
 
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase3RequestDto;
 import com.example.zzapdiz.share.ResponseBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Component
 public interface FundingProejctExceptionInterface {
 
+    /** 생성한 펀딩 프로젝트 1단계 정보 확인 **/
+    ResponseEntity<ResponseBody> checkPhase1Info(FundingProjectCreatePhase1RequestDto fundingProjectCreatePhase1RequestDto);
+
     /** 생성한 펀딩 프로젝트 2단계 정보 확인 **/
     ResponseEntity<ResponseBody> checkPhase2Info(FundingProjectCreatePhase2RequestDto fundingProjectCreatePhase2RequestDto, MultipartFile thumbnailImage);
+
+    /** 생성한 펀딩 프로젝트 3단계 정보 확인 **/
+    ResponseEntity<ResponseBody> checkPhase3Info(FundingProjectCreatePhase3RequestDto fundingProjectCreatePhase3RequestDto, List<MultipartFile> videoAndImages);
+
 
     /** 펀딩 프로젝트 생성 마지막 최종 단계에서 반드시 기입되어야할 정보가 하나라도
      * 명확하지 않다면 에러 응답 처리 **/

--- a/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProjectException.java
+++ b/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProjectException.java
@@ -1,6 +1,8 @@
 package com.example.zzapdiz.exception.fundingproject;
 
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase3RequestDto;
 import com.example.zzapdiz.share.ResponseBody;
 import com.example.zzapdiz.share.StatusCode;
 import org.springframework.http.HttpStatus;
@@ -8,18 +10,49 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-@Component
-public class FundingProjectException implements  FundingProejctExceptionInterface{
+import java.util.List;
 
+@Component
+public class FundingProjectException implements FundingProejctExceptionInterface {
+
+    // 펀딩 프로젝트 생성 1단계 기입 정보들 확인
     @Override
-    public ResponseEntity<ResponseBody> checkPhase2Info(FundingProjectCreatePhase2RequestDto fundingProjectCreatePhase2RequestDto, MultipartFile thumbnailImage) {
-        if(fundingProjectCreatePhase2RequestDto.getProjectTitle() == null ||
-        fundingProjectCreatePhase2RequestDto.getAdultCheck() == null ||
-        fundingProjectCreatePhase2RequestDto.getEndDate() == null ||
-        fundingProjectCreatePhase2RequestDto.getSearchTag() == null ||
-        thumbnailImage == null){
+    public ResponseEntity<ResponseBody> checkPhase1Info(FundingProjectCreatePhase1RequestDto fundingProjectCreatePhase1RequestDto) {
+        if(fundingProjectCreatePhase1RequestDto.getProjectCategory() == null ||
+        fundingProjectCreatePhase1RequestDto.getProjectType() == null ||
+        fundingProjectCreatePhase1RequestDto.getMakerType() == null ||
+        fundingProjectCreatePhase1RequestDto.getRewardType() == null ||
+        fundingProjectCreatePhase1RequestDto.getRewardMakeType() == null ||
+        fundingProjectCreatePhase1RequestDto.getAchievedAmount() == 0){
             return new ResponseEntity<>(new ResponseBody(StatusCode.EXIST_INCORRECTABLE_FUNDING_INFO, null), HttpStatus.BAD_REQUEST);
         }
+
+        return null;
+    }
+
+    // 펀딩 프로젝트 생성 2단계 기입 정보들 확인
+    @Override
+    public ResponseEntity<ResponseBody> checkPhase2Info(FundingProjectCreatePhase2RequestDto fundingProjectCreatePhase2RequestDto, MultipartFile thumbnailImage) {
+        if (fundingProjectCreatePhase2RequestDto.getProjectTitle() == null ||
+                fundingProjectCreatePhase2RequestDto.getAdultCheck() == null ||
+                fundingProjectCreatePhase2RequestDto.getEndDate() == null ||
+                fundingProjectCreatePhase2RequestDto.getSearchTag() == null ||
+                thumbnailImage == null) {
+            return new ResponseEntity<>(new ResponseBody(StatusCode.EXIST_INCORRECTABLE_FUNDING_INFO, null), HttpStatus.BAD_REQUEST);
+        }
+        return null;
+    }
+
+    // 펀딩 프로젝트 생성 3단계 기입 정보들 확인
+    @Override
+    public ResponseEntity<ResponseBody> checkPhase3Info(FundingProjectCreatePhase3RequestDto fundingProjectCreatePhase3RequestDto, List<MultipartFile> videoAndImages) {
+        if (fundingProjectCreatePhase3RequestDto.getProjectDescript() == null ||
+                fundingProjectCreatePhase3RequestDto.getOpenReservation() == null ||
+                fundingProjectCreatePhase3RequestDto.getStoryText() == null ||
+                videoAndImages.isEmpty()) {
+            return new ResponseEntity<>(new ResponseBody(StatusCode.EXIST_INCORRECTABLE_FUNDING_INFO, null), HttpStatus.BAD_REQUEST);
+        }
+
         return null;
     }
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
@@ -2,6 +2,7 @@ package com.example.zzapdiz.fundingproject.controller;
 
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase3RequestDto;
 import com.example.zzapdiz.fundingproject.service.FundingProjectService;
 import com.example.zzapdiz.share.ResponseBody;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -40,6 +42,17 @@ public class FundingProjectController {
         log.info("펀딩 프로젝트 생성 2단계 api : 생성자 - {}, 프로젝트 타이틀 확인 - {}", request, fundingProjectCreatePhase2RequestDto.getProjectTitle());
 
         return fundingProjectService.fundingCreatePhase2(request, fundingProjectCreatePhase2RequestDto, thumbnailImage);
+    }
+
+    /** 펀딩 프로젝트 생성 3단계 **/
+    @PostMapping("/funding/create/phase3")
+    public ResponseEntity<ResponseBody> fundingCreatePhase3(
+            HttpServletRequest request,
+            @RequestPart(value="phase3Request", required = false)FundingProjectCreatePhase3RequestDto fundingProjectCreatePhase3RequestDto,
+            @RequestPart(value="videoAndImages") List<MultipartFile> videoAndImages){
+        log.info("펀딩 프로젝트 생성 3단계 api : 생성자 - {}, 프로젝트 파일 첨부 확인 - {}", request, videoAndImages.get(0));
+
+        return fundingProjectService.fundingCreatePhase3(request, fundingProjectCreatePhase3RequestDto, videoAndImages);
     }
 
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
@@ -1,8 +1,9 @@
 package com.example.zzapdiz.fundingproject.domain;
 
-import com.example.zzapdiz.share.MakerType;
-import com.example.zzapdiz.share.ProjectCategory;
-import com.example.zzapdiz.share.ProjectType;
+import com.example.zzapdiz.share.media.Media;
+import com.example.zzapdiz.share.project.MakerType;
+import com.example.zzapdiz.share.project.ProjectCategory;
+import com.example.zzapdiz.share.project.ProjectType;
 import com.example.zzapdiz.share.Timestamped;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.List;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -44,11 +46,11 @@ public class FundingProject extends Timestamped {
     @Column(nullable = false)
     private String storyText;
 
-    @Column
-    private String storyImage;
-
-    @Column
-    private String storyVideo;
+//    @Column
+//    private String storyImage;
+//
+//    @Column
+//    private String storyVideo;
 
     @Column(nullable = false)
     private String projectDescript;
@@ -62,8 +64,8 @@ public class FundingProject extends Timestamped {
     @Column(nullable = false)
     private LocalDate endDate;
 
-    @Column(nullable = false)
-    private String thumbnailImage;
+//    @Column(nullable = false)
+//    private String thumbnailImage;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -80,5 +82,8 @@ public class FundingProject extends Timestamped {
 
     @Column
     private LocalDate deliveryStartDate;
+
+//    @OneToMany(mappedBy = "fundingProject", fetch = FetchType.LAZY,cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Media> medias;
 
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/request/FundingProjectCreatePhase3RequestDto.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/request/FundingProjectCreatePhase3RequestDto.java
@@ -1,0 +1,18 @@
+package com.example.zzapdiz.fundingproject.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class FundingProjectCreatePhase3RequestDto {
+
+    private String storyText;
+    private String projectDescript;
+    private String openReservation;
+
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/response/FundingProjectCreatePhase1ResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/response/FundingProjectCreatePhase1ResponseDto.java
@@ -1,28 +1,27 @@
 package com.example.zzapdiz.fundingproject.response;
 
 import lombok.*;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.WebApplicationContext;
 
 import java.io.Serializable;
 
-//@ToString
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 @Component
-@Scope(value = WebApplicationContext.SCOPE_SESSION, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@RedisHash(value = "phase1ResponseDto", timeToLive = 1800)
 @Builder
 @Setter
 @Getter
 public class FundingProjectCreatePhase1ResponseDto implements Serializable {
-    // Serializable 을 implements 한 이유 : 이후에 redis에 임시저장하려면 직렬화가 되어있어야 하기 때문이다.
-
+    @Id
+    private Long memberId;
     private String projectCategory;
     private String projectType;
     private String makerType;
     private String rewardType;
     private String rewardMakeType;
     private int achievedAmount;
+
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/response/FundingProjectCreatePhase3ResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/response/FundingProjectCreatePhase3ResponseDto.java
@@ -4,23 +4,20 @@ import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.Serializable;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Component
-@RedisHash(value = "phase2ResponseDto", timeToLive = 1800)
+@RedisHash(value = "phase3ResponseDto", timeToLive = 1800)
 @Builder
 @Setter
 @Getter
-public class FundingProjectCreatePhase2ResponseDto implements Serializable {
+public class FundingProjectCreatePhase3ResponseDto implements Serializable {
     @Id
     private Long memberId;
-    private String projectTitle;
-    private String thumbnailImage;
-    private String endDate;
-    private String adultCheck;
-    private String searchTag;
+    private String storyText;
+    private String projectDescript;
+    private String openReservation;
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
@@ -4,10 +4,19 @@ import com.example.zzapdiz.exception.fundingproject.FundingProjectException;
 import com.example.zzapdiz.exception.member.MemberException;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase3RequestDto;
 import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase1ResponseDto;
 import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase2ResponseDto;
+import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase3ResponseDto;
+import com.example.zzapdiz.jwt.JwtTokenProvider;
+import com.example.zzapdiz.share.media.MediaRepository;
+import com.example.zzapdiz.share.media.MediaUpload;
+import com.example.zzapdiz.share.query.DynamicQueryDsl;
+import com.example.zzapdiz.share.redis.Phase1RedisRepository;
 import com.example.zzapdiz.share.ResponseBody;
 import com.example.zzapdiz.share.StatusCode;
+import com.example.zzapdiz.share.redis.Phase2RedisRepository;
+import com.example.zzapdiz.share.redis.Phase3RedisRepository;
 import com.google.gson.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,13 +26,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -32,28 +43,49 @@ public class FundingProjectService {
 
     private final MemberException memberException;
     private final FundingProjectException fundingProjectException;
-    private final FundingProjectCreatePhase1ResponseDto fundingProjectCreatePhase1ResponseDto;
-    private final FundingProjectCreatePhase2ResponseDto fundingProjectCreatePhase2ResponseDto;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final Phase1RedisRepository phase1RedisRepository;
+    private final Phase2RedisRepository phase2RedisRepository;
+    private final Phase3RedisRepository phase3RedisRepository;
+    private final MediaRepository mediaRepository;
+    private final DynamicQueryDsl dynamicQueryDsl;
+    private final MediaUpload mediaUpload;
 
 
     // 펀딩 프로젝트 생성 1단계
     public ResponseEntity<ResponseBody> fundingCreatePhase1(
             HttpServletRequest request,
-            FundingProjectCreatePhase1RequestDto fundingProjectCreatePhase1RequestDt0){
+            FundingProjectCreatePhase1RequestDto fundingProjectCreatePhase1RequestDt0) {
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
         memberException.checkHeaderToken(request);
+        // 1단계 정보들 확인
+        fundingProjectException.checkPhase1Info(fundingProjectCreatePhase1RequestDt0);
 
-        // spring scope bean 을 사용하여 1단계 생성 정보들을 session으로 어플리케이션 내부에 임시저장
-        // scale out 해서 이후에 서버를 증설한다면 redis로 이전할 필요가 있음
-        fundingProjectCreatePhase1ResponseDto.setProjectCategory(fundingProjectCreatePhase1RequestDt0.getProjectCategory());
-        fundingProjectCreatePhase1ResponseDto.setProjectType(fundingProjectCreatePhase1RequestDt0.getProjectType());
-        fundingProjectCreatePhase1ResponseDto.setMakerType(fundingProjectCreatePhase1RequestDt0.getMakerType());
-        fundingProjectCreatePhase1ResponseDto.setRewardType(fundingProjectCreatePhase1RequestDt0.getRewardType());
-        fundingProjectCreatePhase1ResponseDto.setRewardMakeType(fundingProjectCreatePhase1RequestDt0.getRewardMakeType());
-        fundingProjectCreatePhase1ResponseDto.setAchievedAmount(fundingProjectCreatePhase1RequestDt0.getAchievedAmount());
+        // Redis로 1단계 정보 저장 관리
+        FundingProjectCreatePhase1ResponseDto fundingProjectCreatePhase1ResponseDto = FundingProjectCreatePhase1ResponseDto.builder()
+                .memberId(jwtTokenProvider.getMemberFromAuthentication().getMemberId())
+                .projectCategory(fundingProjectCreatePhase1RequestDt0.getProjectCategory())
+                .projectType(fundingProjectCreatePhase1RequestDt0.getProjectType())
+                .makerType(fundingProjectCreatePhase1RequestDt0.getMakerType())
+                .rewardType(fundingProjectCreatePhase1RequestDt0.getRewardType())
+                .rewardMakeType(fundingProjectCreatePhase1RequestDt0.getRewardMakeType())
+                .achievedAmount(fundingProjectCreatePhase1RequestDt0.getAchievedAmount())
+                .build();
 
-        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, "펀딩 프로젝트 생성 1단계 완료!"), HttpStatus.OK);
+        // 만약 1단계 정보가 저장된 상태에서 다시 저장하려고 할 때 기존 정보 삭제
+        if(phase1RedisRepository.findById(jwtTokenProvider.getMemberFromAuthentication().getMemberId()).isPresent()){
+            phase1RedisRepository.delete(fundingProjectCreatePhase1ResponseDto);
+        }
+
+        // 1단계 정보 저장
+        phase1RedisRepository.save(fundingProjectCreatePhase1ResponseDto);
+
+        HashMap<String, Object> resultSet = new HashMap<>();
+        resultSet.put("createMessage", "펀딩 프로젝트 생성 1단계 완료!");
+        resultSet.put("phase1Info", fundingProjectCreatePhase1ResponseDto);
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, resultSet), HttpStatus.OK);
     }
 
 
@@ -61,55 +93,96 @@ public class FundingProjectService {
     public ResponseEntity<ResponseBody> fundingCreatePhase2(
             HttpServletRequest request,
             FundingProjectCreatePhase2RequestDto fundingProjectCreatePhase2RequestDto,
-            MultipartFile thumbnailImage){
+            MultipartFile thumbnailImage) {
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
         memberException.checkHeaderToken(request);
         // 2단계 정보 확인
         fundingProjectException.checkPhase2Info(fundingProjectCreatePhase2RequestDto, thumbnailImage);
 
-        // sprin scope bean 을 사용하여 2단계 생성 정보들을 session으로 어플리케이션 내부에 저장 및 관리
-        fundingProjectCreatePhase2ResponseDto.setProjectTitle(fundingProjectCreatePhase2RequestDto.getProjectTitle());
-        fundingProjectCreatePhase2ResponseDto.setThumbnailImage(thumbnailImage);
-        fundingProjectCreatePhase2ResponseDto.setEndDate(fundingProjectCreatePhase2RequestDto.getEndDate());
-        fundingProjectCreatePhase2ResponseDto.setAdultCheck(fundingProjectCreatePhase2RequestDto.getAdultCheck());
-        fundingProjectCreatePhase2ResponseDto.setSearchTag(fundingProjectCreatePhase2RequestDto.getSearchTag());
+        // Redis로 2단계 정보 저장 관리
+        FundingProjectCreatePhase2ResponseDto fundingProjectCreatePhase2ResponseDto = FundingProjectCreatePhase2ResponseDto.builder()
+                .memberId(jwtTokenProvider.getMemberFromAuthentication().getMemberId())
+                .projectTitle(fundingProjectCreatePhase2RequestDto.getProjectTitle())
+                .thumbnailImage(thumbnailImage.getOriginalFilename())
+                .endDate(fundingProjectCreatePhase2RequestDto.getEndDate())
+                .adultCheck(fundingProjectCreatePhase2RequestDto.getAdultCheck())
+                .searchTag(fundingProjectCreatePhase2RequestDto.getSearchTag())
+                .build();
+
+        // 이미 2단계 정보를 저장한 상태에서 다시 저장할 경우 기존 정보 삭제
+        if(phase2RedisRepository.findById(jwtTokenProvider.getMemberFromAuthentication().getMemberId()).isPresent()){
+            dynamicQueryDsl.deleteMedia(thumbnailImage);
+            mediaUpload.deleteFile(thumbnailImage.getOriginalFilename());
+            phase2RedisRepository.delete(fundingProjectCreatePhase2ResponseDto);
+        }
+
+        // 대표 썸네일 이미지 저장
+        mediaUpload.uploadMedia(thumbnailImage, "thumb");
+        // 2단계 정보 저장
+        phase2RedisRepository.save(fundingProjectCreatePhase2ResponseDto);
 
         HashMap<String, Object> resultSet = new HashMap<>();
-        resultSet.put("phase2CreateMessage", "펀딩 프로젝트 생성 2단계 완료!");
-        resultSet.put("phase2ResponseInfo", fundingProjectCreatePhase2ResponseDto);
+        resultSet.put("createMessage", "펀딩 프로젝트 생성 2단계 완료!");
+        resultSet.put("phase2Info", fundingProjectCreatePhase2ResponseDto);
 
         return new ResponseEntity<>(new ResponseBody(StatusCode.OK, resultSet), HttpStatus.OK);
     }
 
+
+    // 펀딩 프로젝트 생성 3단계
+    public ResponseEntity<ResponseBody> fundingCreatePhase3(
+            HttpServletRequest request,
+            FundingProjectCreatePhase3RequestDto fundingProjectCreatePhase3RequestDto,
+            List<MultipartFile> videoAndImages) {
+
+        // 생성하는 유저의 id
+        Long memberId = jwtTokenProvider.getMemberFromAuthentication().getMemberId();
+
+        // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
+        memberException.checkHeaderToken(request);
+        // 펀딩 프로젝트 3단계 기입 정보들 확인
+        fundingProjectException.checkPhase3Info(fundingProjectCreatePhase3RequestDto, videoAndImages);
+
+        // Redis로 3단계 정보 저장 관리
+        FundingProjectCreatePhase3ResponseDto fundingProjectCreatePhase3ResponseDto = FundingProjectCreatePhase3ResponseDto.builder()
+                .memberId(memberId)
+                .storyText(fundingProjectCreatePhase3RequestDto.getStoryText())
+                .projectDescript(fundingProjectCreatePhase3RequestDto.getProjectDescript())
+                .openReservation(fundingProjectCreatePhase3RequestDto.getOpenReservation())
+                .build();
+
+        // 이미 3단계 정보를 저장한 상태에서 다시 저장할 경우 기존 정보 삭제
+        if(phase3RedisRepository.findById(jwtTokenProvider.getMemberFromAuthentication().getMemberId()).isPresent()){
+            // s3와 DB에서 미디어 삭제
+            for(int i = 0 ; i < videoAndImages.size() ; i++){
+                dynamicQueryDsl.deleteMedia(videoAndImages.get(i));
+                mediaUpload.deleteFile(videoAndImages.get(i).getOriginalFilename());
+            }
+            // redis에 임시저장한 3단계 정보들 삭제
+            phase3RedisRepository.delete(fundingProjectCreatePhase3ResponseDto);
+        }
+
+        // 업로드하려고하는 여러 장의 미디어마다 저장
+        for(int i = 0 ; i < videoAndImages.size() ; i++){
+            // 대표 썸네일 이미지 저장
+            mediaUpload.uploadMedia(videoAndImages.get(i), "story");
+        }
+
+        // 생성 정보 저장
+        phase3RedisRepository.save(fundingProjectCreatePhase3ResponseDto);
+
+        HashMap<String, Object> resultSet = new HashMap<>();
+        resultSet.put("createMessage", "펀딩 프로젝트 생성 3단계 완료!!");
+        resultSet.put("phase3Info", fundingProjectCreatePhase3ResponseDto);
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, resultSet), HttpStatus.OK);
+    }
+
+
     // Gson().toJson("Json 객체 혹은 Dto 객체") -> Json 형식의 객체를 String 타입으로 변환
     // Gson().fromJson("String 타입으로 변환된 객체", 변환될 Json 형식객체 혹은 DTO 객체.class) -> String 타입으로 변환된 Json 객체를 다시 Json 형식으로 변환
 
-    // GSON에서 LocalDate 유형의 데이터를 String 타입으로 변환하기 위한 설정
-    private Gson gsonConverterFactory() {
-        Gson gson = new GsonBuilder()
-                .registerTypeAdapter(LocalDateTime.class, new JsonDeserializer<LocalDateTime>() {
-                    @Override
-                    public LocalDateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-                        return LocalDateTime.parse(json.getAsString(), DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
-                    }
-                })
-                .registerTypeAdapter(LocalDate.class, new JsonDeserializer<LocalDate>() {
-                    @Override
-                    public LocalDate deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-                        return LocalDate.parse(json.getAsString(), DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-                    }
-                })
-                .registerTypeAdapter(LocalTime.class, new JsonDeserializer<LocalTime>() {
-                    @Override
-                    public LocalTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-                        return LocalTime.parse(json.getAsString(), DateTimeFormatter.ofPattern("HH:mm:ss"));
-                    }
-                })
-                .create();
-
-        return gson;
-    }
 }
 
 

--- a/src/main/java/com/example/zzapdiz/member/controller/MemberController.java
+++ b/src/main/java/com/example/zzapdiz/member/controller/MemberController.java
@@ -1,14 +1,12 @@
 package com.example.zzapdiz.member.controller;
 
-import com.example.zzapdiz.member.request.MemberFindRequestDto;
 import com.example.zzapdiz.member.request.MemberLoginRequestDto;
 import com.example.zzapdiz.member.request.MemberSignupRequestDto;
 import com.example.zzapdiz.member.service.MemberService;
-import com.example.zzapdiz.share.MailDto;
+import com.example.zzapdiz.share.mail.MailDto;
 import com.example.zzapdiz.share.ResponseBody;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/example/zzapdiz/member/service/MemberService.java
+++ b/src/main/java/com/example/zzapdiz/member/service/MemberService.java
@@ -9,8 +9,8 @@ import com.example.zzapdiz.member.domain.Member;
 import com.example.zzapdiz.member.repository.MemberRepository;
 import com.example.zzapdiz.member.request.MemberLoginRequestDto;
 import com.example.zzapdiz.member.request.MemberSignupRequestDto;
-import com.example.zzapdiz.share.DynamicQueryDsl;
-import com.example.zzapdiz.share.MailDto;
+import com.example.zzapdiz.share.query.DynamicQueryDsl;
+import com.example.zzapdiz.share.mail.MailDto;
 import com.example.zzapdiz.share.ResponseBody;
 import com.example.zzapdiz.share.StatusCode;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -32,8 +32,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 import java.util.Properties;
-
-import static com.example.zzapdiz.member.domain.QMember.member;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/com/example/zzapdiz/member/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/zzapdiz/member/service/UserDetailsServiceImpl.java
@@ -2,7 +2,7 @@ package com.example.zzapdiz.member.service;
 
 import com.example.zzapdiz.exception.member.MemberExceptionInterface;
 import com.example.zzapdiz.member.domain.Member;
-import com.example.zzapdiz.share.DynamicQueryDsl;
+import com.example.zzapdiz.share.query.DynamicQueryDsl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.User;

--- a/src/main/java/com/example/zzapdiz/reward/Reward.java
+++ b/src/main/java/com/example/zzapdiz/reward/Reward.java
@@ -1,6 +1,6 @@
 package com.example.zzapdiz.reward;
 
-import com.example.zzapdiz.share.RewardMakeType;
+import com.example.zzapdiz.share.project.RewardMakeType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/zzapdiz/share/mail/MailDto.java
+++ b/src/main/java/com/example/zzapdiz/share/mail/MailDto.java
@@ -1,4 +1,4 @@
-package com.example.zzapdiz.share;
+package com.example.zzapdiz.share.mail;
 
 import lombok.Getter;
 

--- a/src/main/java/com/example/zzapdiz/share/media/Media.java
+++ b/src/main/java/com/example/zzapdiz/share/media/Media.java
@@ -1,0 +1,43 @@
+package com.example.zzapdiz.share.media;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+@Entity
+public class Media {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long mediaId;
+
+    @Column(nullable = false)
+    private String mediaRealName;
+
+    @Column(nullable = false)
+    private String mediaUidName;
+
+    @Column(nullable = false)
+    private String mediaType;
+
+    @Column
+    private String mediaUrl;
+
+    @Column(nullable = false)
+    private String mediaPurpose;
+
+    @Column
+    private Long fundingProjectId;
+
+//    @JoinColumn(name = "fundingProjectId", nullable = false)
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    private FundingProject fundingProject;
+}

--- a/src/main/java/com/example/zzapdiz/share/media/MediaRepository.java
+++ b/src/main/java/com/example/zzapdiz/share/media/MediaRepository.java
@@ -1,0 +1,9 @@
+package com.example.zzapdiz.share.media;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MediaRepository extends JpaRepository<Media, Long> {
+
+}

--- a/src/main/java/com/example/zzapdiz/share/media/MediaUpload.java
+++ b/src/main/java/com/example/zzapdiz/share/media/MediaUpload.java
@@ -1,0 +1,90 @@
+package com.example.zzapdiz.share.media;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class MediaUpload implements MediaUploadInterface {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 amazonS3;
+
+    private final MediaRepository mediaRepository;
+
+    @Override
+    public Media uploadMedia(MultipartFile media, String mediaPurpose) {
+
+        String mediaName = createFileName(media.getOriginalFilename()); // 각 파일의 이름을 저장
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(media.getSize());
+        objectMetadata.setContentType(media.getContentType());
+
+        System.out.println("for each 진입 : " + mediaName);
+
+        try (InputStream inputStream = media.getInputStream()) {
+            // S3에 업로드 및 저장
+            amazonS3.putObject(new PutObjectRequest(bucket, media.getOriginalFilename(), inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
+        }
+
+        // 접근가능한 URL 가져오기
+        String mediaUrl = amazonS3.getUrl(bucket, mediaName).toString();
+
+        // 동시에 해당 미디어 파일들을 미디어 DB에 이름과 Url 정보 저장.
+        // 게시글마다 어떤 미디어 파일들을 포함하고 있는지 파악하기 위함 또는 활용하기 위함.
+        Media uploadMedia = Media.builder()
+                .mediaRealName(media.getOriginalFilename())
+                .mediaUidName(mediaName)
+                .mediaType(media.getContentType())
+                .mediaUrl(mediaUrl)
+                .mediaPurpose(mediaPurpose)
+                .build();
+
+        mediaRepository.save(uploadMedia);
+
+        return uploadMedia;
+    }
+
+    // S3에 저장되어있는 미디어 파일 삭제
+    @Override
+    public void deleteFile(String fileName) {
+        amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
+    }
+
+
+    // 파일 업로드 시, 파일명을 난수화하기 위해 random으로 돌린다. (현재는 굳이 난수화할 필요가 없어보여 사용하지 않음)
+    @Override
+    public String createFileName(String fileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+    }
+
+
+    // file 형식이 잘못된 경우를 확인하기 위해 만들어진 로직이며, 파일 타입과 상관없이 업로드할 수 있게 하기 위해 .의 존재 유무만 판단하였습니다.
+    @Override
+    public String getFileExtension(String fileName) {
+        try {
+            return fileName.substring(fileName.lastIndexOf("."));
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일(" + fileName + ") 입니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/zzapdiz/share/media/MediaUploadInterface.java
+++ b/src/main/java/com/example/zzapdiz/share/media/MediaUploadInterface.java
@@ -1,0 +1,11 @@
+package com.example.zzapdiz.share.media;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface MediaUploadInterface {
+
+    Media uploadMedia(MultipartFile media, String mediaPurpose);
+    void deleteFile(String fileName);
+    String createFileName(String fileName);
+    String getFileExtension(String fileName);
+}

--- a/src/main/java/com/example/zzapdiz/share/project/MakerType.java
+++ b/src/main/java/com/example/zzapdiz/share/project/MakerType.java
@@ -1,4 +1,4 @@
-package com.example.zzapdiz.share;
+package com.example.zzapdiz.share.project;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/zzapdiz/share/project/ProjectCategory.java
+++ b/src/main/java/com/example/zzapdiz/share/project/ProjectCategory.java
@@ -1,4 +1,4 @@
-package com.example.zzapdiz.share;
+package com.example.zzapdiz.share.project;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/zzapdiz/share/project/ProjectType.java
+++ b/src/main/java/com/example/zzapdiz/share/project/ProjectType.java
@@ -1,4 +1,4 @@
-package com.example.zzapdiz.share;
+package com.example.zzapdiz.share.project;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/zzapdiz/share/project/RewardMakeType.java
+++ b/src/main/java/com/example/zzapdiz/share/project/RewardMakeType.java
@@ -1,4 +1,4 @@
-package com.example.zzapdiz.share;
+package com.example.zzapdiz.share.project;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/zzapdiz/share/query/DynamicQueryDsl.java
+++ b/src/main/java/com/example/zzapdiz/share/query/DynamicQueryDsl.java
@@ -1,4 +1,4 @@
-package com.example.zzapdiz.share;
+package com.example.zzapdiz.share.query;
 
 import com.example.zzapdiz.member.domain.Member;
 import com.example.zzapdiz.member.request.MemberFindRequestDto;
@@ -8,11 +8,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityManager;
 
 import static com.example.zzapdiz.member.domain.QMember.member;
 import static com.example.zzapdiz.jwt.domain.QToken.token;
+import static com.example.zzapdiz.share.media.QMedia.media;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -91,5 +93,18 @@ public class DynamicQueryDsl {
         entityManager.flush();
         entityManager.clear();
     }
+
+    /** 미디어 삭제 **/
+    @Transactional
+    public void deleteMedia(MultipartFile requestMedia){
+        jpaQueryFactory
+                .delete(media)
+                .where(media.mediaRealName.eq(requestMedia.getOriginalFilename()))
+                .execute();
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
 
 }

--- a/src/main/java/com/example/zzapdiz/share/redis/Phase1RedisRepository.java
+++ b/src/main/java/com/example/zzapdiz/share/redis/Phase1RedisRepository.java
@@ -1,0 +1,12 @@
+package com.example.zzapdiz.share.redis;
+
+import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase1ResponseDto;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface Phase1RedisRepository extends CrudRepository<FundingProjectCreatePhase1ResponseDto, Long> {
+    Optional<FundingProjectCreatePhase1ResponseDto> findById(Long id);
+}

--- a/src/main/java/com/example/zzapdiz/share/redis/Phase2RedisRepository.java
+++ b/src/main/java/com/example/zzapdiz/share/redis/Phase2RedisRepository.java
@@ -1,0 +1,12 @@
+package com.example.zzapdiz.share.redis;
+
+import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase2ResponseDto;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface Phase2RedisRepository extends CrudRepository<FundingProjectCreatePhase2ResponseDto, Long> {
+    Optional<FundingProjectCreatePhase2ResponseDto> findById(Long id);
+}

--- a/src/main/java/com/example/zzapdiz/share/redis/Phase3RedisRepository.java
+++ b/src/main/java/com/example/zzapdiz/share/redis/Phase3RedisRepository.java
@@ -1,0 +1,12 @@
+package com.example.zzapdiz.share.redis;
+
+import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase3ResponseDto;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface Phase3RedisRepository extends CrudRepository<FundingProjectCreatePhase3ResponseDto, Long> {
+    Optional<FundingProjectCreatePhase3ResponseDto> findById(Long id);
+}

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
@@ -3,8 +3,10 @@ package com.example.zzapdiz.fundingproject;
 import com.example.zzapdiz.fundingproject.controller.FundingProjectController;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
+import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase3RequestDto;
 import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase1ResponseDto;
 import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase2ResponseDto;
+import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase3ResponseDto;
 import com.example.zzapdiz.fundingproject.service.FundingProjectService;
 import com.example.zzapdiz.member.domain.Member;
 import com.example.zzapdiz.member.request.MemberSignupRequestDto;
@@ -23,13 +25,19 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
 
-import static org.mockito.ArgumentMatchers.any;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -89,8 +97,6 @@ public class FundingProjectConrollerTest {
                 .when(fundingProjectService)
                 .fundingCreatePhase2(any(MockHttpServletRequest.class), any(FundingProjectCreatePhase2RequestDto.class), any(MockMultipartFile.class));
 
-        System.out.println(phase2RequestDto().getProjectTitle());
-
         String phase2RequestDto = new Gson().toJson(phase2RequestDto());
 
         // when
@@ -105,6 +111,32 @@ public class FundingProjectConrollerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.projectTitle").value(phase2RequestDto().getProjectTitle()));
+
+    }
+
+    @DisplayName("[FundingProjectController] 펀딩 프로젝트 생성 3단계 api")
+    @Test
+    void createFundingPhase3() throws Exception {
+        // given
+        
+        doReturn(new ResponseEntity<>(new ResponseBody(StatusCode.OK, phase3ResponseDto()), HttpStatus.OK))
+                .when(fundingProjectService)
+                .fundingCreatePhase3(any(MockHttpServletRequest.class), any(FundingProjectCreatePhase3RequestDto.class), anyList());
+
+        String phase3RequestDto = new Gson().toJson(phase3RequestDto());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post("/zzapdiz/funding/create/phase3")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding("utf-8")
+                        .content(phase3RequestDto));
+        // then
+        ResultActions resultActionsThen = resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.phase3Info.storyText").value(phase3RequestDto().getStoryText()));
 
     }
 
@@ -145,6 +177,23 @@ public class FundingProjectConrollerTest {
                 .endDate("20230314")
                 .adultCheck("O")
                 .searchTag("#검색태그1-#검색태그2")
+                .build();
+    }
+
+    private FundingProjectCreatePhase3RequestDto phase3RequestDto() {
+        return FundingProjectCreatePhase3RequestDto.builder()
+                .storyText("프로젝트 소개글 완성")
+                .projectDescript("프로젝트 요약 설명")
+                .openReservation("O")
+                .build();
+    }
+
+    private FundingProjectCreatePhase3ResponseDto phase3ResponseDto(){
+        return FundingProjectCreatePhase3ResponseDto.builder()
+                .memberId(1L)
+                .storyText("프로젝트 소개글 완성")
+                .projectDescript("프로젝트 요약 설명 완성")
+                .openReservation("O")
                 .build();
     }
 }

--- a/src/test/java/com/example/zzapdiz/member/MemberConrollerTest.java
+++ b/src/test/java/com/example/zzapdiz/member/MemberConrollerTest.java
@@ -1,14 +1,13 @@
 package com.example.zzapdiz.member;
 
 import com.example.zzapdiz.jwt.JwtTokenProvider;
-import com.example.zzapdiz.jwt.dto.TokenDto;
 import com.example.zzapdiz.member.controller.MemberController;
 import com.example.zzapdiz.member.domain.Member;
 import com.example.zzapdiz.member.request.MemberLoginRequestDto;
 import com.example.zzapdiz.member.request.MemberSignupRequestDto;
 import com.example.zzapdiz.member.response.MemberSignupResponseDto;
 import com.example.zzapdiz.member.service.MemberService;
-import com.example.zzapdiz.share.DynamicQueryDsl;
+import com.example.zzapdiz.share.query.DynamicQueryDsl;
 import com.example.zzapdiz.share.ResponseBody;
 import com.example.zzapdiz.share.StatusCode;
 import com.google.gson.Gson;
@@ -22,17 +21,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.core.Authentication;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/com/example/zzapdiz/member/MemberServiceTest.java
+++ b/src/test/java/com/example/zzapdiz/member/MemberServiceTest.java
@@ -9,7 +9,7 @@ import com.example.zzapdiz.member.request.MemberLoginRequestDto;
 import com.example.zzapdiz.member.request.MemberSignupRequestDto;
 import com.example.zzapdiz.member.response.MemberSignupResponseDto;
 import com.example.zzapdiz.member.service.MemberService;
-import com.example.zzapdiz.share.DynamicQueryDsl;
+import com.example.zzapdiz.share.query.DynamicQueryDsl;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/example/zzapdiz/redis/RedisTest.java
+++ b/src/test/java/com/example/zzapdiz/redis/RedisTest.java
@@ -1,0 +1,44 @@
+package com.example.zzapdiz.redis;
+
+import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase1ResponseDto;
+import com.example.zzapdiz.share.redis.Phase1RedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+public class RedisTest {
+
+    @Autowired
+    private Phase1RedisRepository phase1RedisRepository;
+
+    @DisplayName("[RedisTest] Phase1 정보 확인")
+    @Test
+    void phase1test() {
+
+        phase1RedisRepository.save(phase1ResponseDto());
+
+        Optional<FundingProjectCreatePhase1ResponseDto> fundingProjectCreatePhase1ResponseDto = phase1RedisRepository.findById(phase1ResponseDto().getMemberId());
+
+        System.out.println(fundingProjectCreatePhase1ResponseDto.get().getProjectType());
+        System.out.println(phase1RedisRepository.count());
+    }
+
+    private FundingProjectCreatePhase1ResponseDto phase1ResponseDto() {
+        return FundingProjectCreatePhase1ResponseDto.builder()
+                .memberId(1L)
+                .projectCategory("테크/가전")
+                .projectType("ODM")
+                .makerType("개인")
+                .rewardType("인테리어")
+                .rewardMakeType("ODM")
+                .build();
+    }
+}


### PR DESCRIPTION
[Feature/Funding/Create/Phase3]
- FundingProjectController 펀딩 프로젝트 생성 3단계 api 1차 구현
- FundingProjectService 펀딩 프로젝트 생성 3단계 비즈니스 로직 1차 구현
- FundingProject 엔티티의 thumbnailImage, storyVideo, storyImage 속성을 제거 Media 엔티티로 따로 생성 및 관리
- 펀딩 프로젝트 3단계 생성 요청을 위한 FundingProjectCreatePhase3RequestDto 객체 생성
- 펀딩 프로젝트 3단계 생성 후 임시저장을 위해 RedisHash로 Redis에 저장할 FundingProjectCreatePhase3ResponseDto 객체 생성
- 기존의 Spring Scope Bean으로 어플리케이션 내부에서 session으로 단계 정보들을 관리하는 것은 폐기 처리
- 펀딩 프로젝트 1단계, 2단계 Dto 모두 외부의 Redis에서 관리하는 것이 낫다고 판단하여 RedisHash로 Redis 객체로 변환
- Redis를 사용하기위한 RedisConfig 설정 클래스 생성
- 펀딩 생성 1단계, 2단계, 3단계 Redis 객체용 RedisRepository 생성
- 펀딩 프로젝트 1단계, 2단계, 3단계 정보들의 null 값 확인 interface 추가
- 이미지와 영상같은 미디어 자원 관리용 Media 엔티티 생성
- MediaRepository 생성
- 미디어 파일들을 프론트 단에서 구현할 때 이용하기 쉽게 AWS S3 사용
- S3 사용을 위한 AwsS3Config 클래스 파일 생성
- DB에 미디어 파일 업로드하는 것과 S3에 업로드하는 기능을 포함한 MediaUpload 인터페이스 생성
- AWS 사용 설정값과 Redis 설정값을 관리할 application.yml 파일 생성
- Redis와 AWS 관련 dependency 추가