### PR TITLE
펀딩 프로젝트 생성 5단계 api 1차 구현

### DIFF
--- a/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProejctExceptionInterface.java
+++ b/src/main/java/com/example/zzapdiz/exception/fundingproject/FundingProejctExceptionInterface.java
@@ -4,9 +4,7 @@ import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1Requ
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase3RequestDto;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase4RequestDto;
-import com.example.zzapdiz.reward.request.RewardCreateRequestDto;
 import com.example.zzapdiz.share.ResponseBody;
-import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,11 +28,18 @@ public interface FundingProejctExceptionInterface {
     /** 생성한 펀딩 프로젝트 4단계 정보 확인 **/
     ResponseEntity<ResponseBody> checkPhase4Info(FundingProjectCreatePhase4RequestDto fundingProjectCreatePhase4RequestDto);
 
+    /** 펀딩 프로젝트의 타이틀 명은 중복될 수 없음을 확인 **/
+    ResponseEntity<ResponseBody> checkDuplicatedTitle(String projectTitle);
+
 
     // [상황에 따른 예외 응답 처리]
 
     /** 배송 여부 확인 후 특정배송 시 최소 3000원 배송비 포함, 특정배송이 아닌 기본배송일 경우 배송비 0원 반환 **/
     int deliveryChecking(String deliveryCheck);
+
+    /** OpenReservation이 O이라면 startDate 속성의 값을 기입받은 openReservationStartDate로 넣는다.
+     X라면 프로젝트가 생성되 바로 그 즉시 시점의 시간대를 startDate 속성에 넣는다. **/
+    String startDateSetting(String openReservation, String openReservationStartdate);
 
     /** 펀딩 프로젝트 생성 마지막 최종 단계에서 반드시 기입되어야할 정보가 하나라도
      * 명확하지 않다면 에러 응답 처리 **/

--- a/src/main/java/com/example/zzapdiz/exception/reward/RewardException.java
+++ b/src/main/java/com/example/zzapdiz/exception/reward/RewardException.java
@@ -13,10 +13,24 @@ import java.util.List;
 public class RewardException implements RewardExceptionInterface {
 
     // 리워드 생성 시 수량 체크
-    public ResponseEntity<ResponseBody> rewardAmountCheck(List<RewardCreateRequestDto> rewardCreateRequestDtos){
-        for(RewardCreateRequestDto rewardCreateRequestDto : rewardCreateRequestDtos){
-            if(rewardCreateRequestDto.getRewardAmount() > 0 && rewardCreateRequestDto.getRewardAmount() < 50){
+    public ResponseEntity<ResponseBody> checkRewardAmount(List<RewardCreateRequestDto> rewardCreateRequestDtos) {
+        for (RewardCreateRequestDto rewardCreateRequestDto : rewardCreateRequestDtos) {
+            if (rewardCreateRequestDto.getRewardAmount() > 0 && rewardCreateRequestDto.getRewardAmount() < 50) {
                 return new ResponseEntity<>(new ResponseBody(StatusCode.NEED_AMOUNT_CHECK, null), HttpStatus.BAD_REQUEST);
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<ResponseBody> checkRewardInfo(List<RewardCreateRequestDto> rewardCreateRequestDtos) {
+        for (RewardCreateRequestDto reward : rewardCreateRequestDtos) {
+            if (reward.getRewardAmount() == 0 ||
+                    reward.getRewardContent() == null ||
+                    reward.getRewardTitle() == null ||
+                    reward.getRewardQuantity() == 0) {
+                return new ResponseEntity<>(new ResponseBody(StatusCode.NEED_REWARD_INFO_CHECK, null), HttpStatus.BAD_REQUEST);
             }
         }
 

--- a/src/main/java/com/example/zzapdiz/exception/reward/RewardExceptionInterface.java
+++ b/src/main/java/com/example/zzapdiz/exception/reward/RewardExceptionInterface.java
@@ -11,5 +11,8 @@ import java.util.List;
 public interface RewardExceptionInterface {
 
     /** 리워드 생성 시 수량 체크 **/
-    ResponseEntity<ResponseBody> rewardAmountCheck(List<RewardCreateRequestDto> rewardCreateRequestDtos);
+    ResponseEntity<ResponseBody> checkRewardAmount(List<RewardCreateRequestDto> rewardCreateRequestDtos);
+
+    /** 리워드들 정보 확인 **/
+    ResponseEntity<ResponseBody> checkRewardInfo(List<RewardCreateRequestDto> rewardCreateRequestDtos);
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
@@ -68,4 +68,13 @@ public class FundingProjectController {
         return fundingProjectService.fundingCreatePhase4(request, fundingProjectCreatePhase4RequestDto, rewardCreateRequestDtos);
     }
 
+    /** 펀딩 프로젝트 생성 5단계 마지막 **/
+    @PostMapping("/funding/create/phase5")
+    public ResponseEntity<ResponseBody> fundingCreateFinal(HttpServletRequest request){
+        log.info("펀딩 프로젝트 생성 5단계 마지막 api : 생성자 - {}", request);
+
+        return fundingProjectService.fundingCreateFinal(request);
+    }
+
+
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
@@ -1,20 +1,25 @@
 package com.example.zzapdiz.fundingproject.domain;
 
+import com.example.zzapdiz.reward.domain.Reward;
 import com.example.zzapdiz.share.media.Media;
 import com.example.zzapdiz.share.project.MakerType;
 import com.example.zzapdiz.share.project.ProjectCategory;
 import com.example.zzapdiz.share.project.ProjectType;
 import com.example.zzapdiz.share.Timestamped;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 @Builder
 @Entity
 public class FundingProject extends Timestamped {
@@ -27,12 +32,10 @@ public class FundingProject extends Timestamped {
     private String projectTitle;
 
     @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private ProjectCategory projectCategory;
+    private String projectCategory;
 
     @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private ProjectType projectType;
+    private String projectType;
 
     @Column(nullable = false)
     private int achievedAmount;
@@ -59,17 +62,16 @@ public class FundingProject extends Timestamped {
     private String openReservation;
 
     @Column(nullable = false)
-    private LocalDate startDate;
+    private LocalDateTime startDate;
 
     @Column(nullable = false)
-    private LocalDate endDate;
+    private LocalDateTime endDate;
 
 //    @Column(nullable = false)
 //    private String thumbnailImage;
 
     @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private MakerType makerType;
+    private String makerType;
 
     @Column(nullable = false)
     private String progress;
@@ -78,10 +80,14 @@ public class FundingProject extends Timestamped {
     private String deliveryCheck;
 
     @Column
-    private String deliveryPrice;
+    private int deliveryPrice;
 
     @Column
-    private LocalDate deliveryStartDate;
+    private LocalDateTime deliveryStartDate;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "fundingProject", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Reward> rewards;
 
 //    @OneToMany(mappedBy = "fundingProject", fetch = FetchType.LAZY,cascade = CascadeType.ALL, orphanRemoval = true)
 //    private List<Media> medias;

--- a/src/main/java/com/example/zzapdiz/fundingproject/response/FundingProjectCreatePhase3ResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/response/FundingProjectCreatePhase3ResponseDto.java
@@ -20,4 +20,5 @@ public class FundingProjectCreatePhase3ResponseDto implements Serializable {
     private String storyText;
     private String projectDescript;
     private String openReservation;
+    private String openReservationStartDate;
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
@@ -1,14 +1,10 @@
 package com.example.zzapdiz.fundingproject.service;
 
 import com.example.zzapdiz.exception.fundingproject.FundingProejctExceptionInterface;
-import com.example.zzapdiz.exception.fundingproject.FundingProjectException;
-import com.example.zzapdiz.exception.member.MemberException;
 import com.example.zzapdiz.exception.member.MemberExceptionInterface;
 import com.example.zzapdiz.exception.reward.RewardExceptionInterface;
-import com.example.zzapdiz.fundingproject.repository.Phase1RedisRepository;
-import com.example.zzapdiz.fundingproject.repository.Phase2RedisRepository;
-import com.example.zzapdiz.fundingproject.repository.Phase3RedisRepository;
-import com.example.zzapdiz.fundingproject.repository.Phase4RedisRepository;
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.fundingproject.repository.*;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase3RequestDto;
@@ -18,44 +14,61 @@ import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase2Res
 import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase3ResponseDto;
 import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase4ResponseDto;
 import com.example.zzapdiz.jwt.JwtTokenProvider;
+import com.example.zzapdiz.member.domain.Member;
+import com.example.zzapdiz.reward.domain.Reward;
+import com.example.zzapdiz.reward.repository.RewardRepository;
 import com.example.zzapdiz.reward.request.RewardCreateRequestDto;
 import com.example.zzapdiz.reward.response.RewardCreateResponseDto;
 import com.example.zzapdiz.reward.repository.RewardRedisRepository;
-import com.example.zzapdiz.share.media.MediaUpload;
+import com.example.zzapdiz.rewardoption.domain.RewardOption;
+import com.example.zzapdiz.rewardoption.repository.RewardOptionRepository;
+import com.example.zzapdiz.share.media.Media;
+import com.example.zzapdiz.share.media.MediaUploadInterface;
+import com.example.zzapdiz.share.project.MakerType;
+import com.example.zzapdiz.share.project.ProjectCategory;
+import com.example.zzapdiz.share.project.ProjectType;
+import com.example.zzapdiz.share.project.RewardMakeType;
 import com.example.zzapdiz.share.query.DynamicQueryDsl;
 import com.example.zzapdiz.share.ResponseBody;
 import com.example.zzapdiz.share.StatusCode;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class FundingProjectService {
 
-    private final MemberExceptionInterface memberException;
-    private final FundingProejctExceptionInterface fundingProjectException;
+    // 인터페이스
+    private final MemberExceptionInterface memberExceptionInterface;
+    private final FundingProejctExceptionInterface fundingProejctExceptionInterface;
     private final RewardExceptionInterface rewardExceptionInterface;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final MediaUploadInterface mediaUploadInterface;
+
+    // Repository
     private final Phase1RedisRepository phase1RedisRepository;
     private final Phase2RedisRepository phase2RedisRepository;
     private final Phase3RedisRepository phase3RedisRepository;
     private final Phase4RedisRepository phase4RedisRepository;
     private final RewardRedisRepository rewardRedisRepository;
-    private final DynamicQueryDsl dynamicQueryDsl;
-    private final MediaUpload mediaUpload;
+    private final FundingProjectRepository fundingProjectRepository;
+    private final RewardRepository rewardRepository;
+    private final RewardOptionRepository rewardOptionRepository;
 
+    // 기타 의존성
+    private final JwtTokenProvider jwtTokenProvider;
+    private final DynamicQueryDsl dynamicQueryDsl;
+    private static final HashMap<Long, List<RewardCreateResponseDto>> rewards = new HashMap<>();
 
     // 펀딩 프로젝트 생성 1단계
     public ResponseEntity<ResponseBody> fundingCreatePhase1(
@@ -66,9 +79,9 @@ public class FundingProjectService {
         Long memberId = jwtTokenProvider.getMemberFromAuthentication().getMemberId();
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
-        memberException.checkHeaderToken(request);
+        memberExceptionInterface.checkHeaderToken(request);
         // 1단계 정보들 확인
-        fundingProjectException.checkPhase1Info(fundingProjectCreatePhase1RequestDt0);
+        fundingProejctExceptionInterface.checkPhase1Info(fundingProjectCreatePhase1RequestDt0);
 
         // Redis로 1단계 정보 저장 관리
         FundingProjectCreatePhase1ResponseDto fundingProjectCreatePhase1ResponseDto = FundingProjectCreatePhase1ResponseDto.builder()
@@ -82,7 +95,7 @@ public class FundingProjectService {
                 .build();
 
         // 만약 1단계 정보가 저장된 상태에서 다시 저장하려고 할 때 기존 정보 삭제
-        if(phase1RedisRepository.findById(memberId).isPresent()){
+        if (phase1RedisRepository.findById(memberId).isPresent()) {
             phase1RedisRepository.deleteById(memberId);
         }
 
@@ -107,9 +120,10 @@ public class FundingProjectService {
         Long memberId = jwtTokenProvider.getMemberFromAuthentication().getMemberId();
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
-        memberException.checkHeaderToken(request);
+        memberExceptionInterface.checkHeaderToken(request);
         // 2단계 정보 확인
-        fundingProjectException.checkPhase2Info(fundingProjectCreatePhase2RequestDto, thumbnailImage);
+        fundingProejctExceptionInterface.checkPhase2Info(fundingProjectCreatePhase2RequestDto, thumbnailImage);
+        fundingProejctExceptionInterface.checkDuplicatedTitle(fundingProjectCreatePhase2RequestDto.getProjectTitle());
 
         // Redis로 2단계 정보 저장 관리
         FundingProjectCreatePhase2ResponseDto fundingProjectCreatePhase2ResponseDto = FundingProjectCreatePhase2ResponseDto.builder()
@@ -122,14 +136,14 @@ public class FundingProjectService {
                 .build();
 
         // 이미 2단계 정보를 저장한 상태에서 다시 저장할 경우 기존 정보 삭제
-        if(phase2RedisRepository.findById(memberId).isPresent()){
+        if (phase2RedisRepository.findById(memberId).isPresent()) {
             dynamicQueryDsl.deleteMedia(thumbnailImage);
-            mediaUpload.deleteFile(thumbnailImage.getOriginalFilename());
+            mediaUploadInterface.deleteFile(thumbnailImage.getOriginalFilename());
             phase2RedisRepository.deleteById(memberId);
         }
 
         // 대표 썸네일 이미지 저장
-        mediaUpload.uploadMedia(thumbnailImage, "thumb");
+        mediaUploadInterface.uploadMedia(thumbnailImage, "thumb", fundingProjectCreatePhase2RequestDto.getProjectTitle());
         // 2단계 정보 저장
         phase2RedisRepository.save(fundingProjectCreatePhase2ResponseDto);
 
@@ -151,9 +165,9 @@ public class FundingProjectService {
         Long memberId = jwtTokenProvider.getMemberFromAuthentication().getMemberId();
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
-        memberException.checkHeaderToken(request);
+        memberExceptionInterface.checkHeaderToken(request);
         // 펀딩 프로젝트 3단계 기입 정보들 확인
-        fundingProjectException.checkPhase3Info(fundingProjectCreatePhase3RequestDto, videoAndImages);
+        fundingProejctExceptionInterface.checkPhase3Info(fundingProjectCreatePhase3RequestDto, videoAndImages);
 
         // Redis로 3단계 정보 저장 관리
         FundingProjectCreatePhase3ResponseDto fundingProjectCreatePhase3ResponseDto = FundingProjectCreatePhase3ResponseDto.builder()
@@ -164,20 +178,20 @@ public class FundingProjectService {
                 .build();
 
         // 이미 3단계 정보를 저장한 상태에서 다시 저장할 경우 기존 정보 삭제
-        if(phase3RedisRepository.findById(memberId).isPresent()){
+        if (phase3RedisRepository.findById(memberId).isPresent()) {
             // s3와 DB에서 미디어 삭제
-            for(int i = 0 ; i < videoAndImages.size() ; i++){
+            for (int i = 0; i < videoAndImages.size(); i++) {
                 dynamicQueryDsl.deleteMedia(videoAndImages.get(i));
-                mediaUpload.deleteFile(videoAndImages.get(i).getOriginalFilename());
+                mediaUploadInterface.deleteFile(videoAndImages.get(i).getOriginalFilename());
             }
             // redis에 임시저장한 3단계 정보들 삭제
             phase3RedisRepository.deleteById(memberId);
         }
 
         // 업로드하려고하는 여러 장의 미디어마다 저장
-        for(int i = 0 ; i < videoAndImages.size() ; i++){
+        for (int i = 0; i < videoAndImages.size(); i++) {
             // 대표 썸네일 이미지 저장
-            mediaUpload.uploadMedia(videoAndImages.get(i), "story");
+            mediaUploadInterface.uploadMedia(videoAndImages.get(i), "story", phase2RedisRepository.findById(memberId).get().getProjectTitle());
         }
 
         // 생성 정보 저장
@@ -195,38 +209,39 @@ public class FundingProjectService {
     public ResponseEntity<ResponseBody> fundingCreatePhase4(
             HttpServletRequest request,
             FundingProjectCreatePhase4RequestDto fundingProjectCreatePhase4RequestDto,
-            List<RewardCreateRequestDto> rewardCreateRequestDtos){
+            List<RewardCreateRequestDto> rewardCreateRequestDtos) {
 
+        Member authMember = jwtTokenProvider.getMemberFromAuthentication();
         Long memberId = jwtTokenProvider.getMemberFromAuthentication().getMemberId();
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
-        memberException.checkHeaderToken(request);
+        memberExceptionInterface.checkHeaderToken(request);
         // 펀딩 프로젝트 4단계 기입 정보들 확인
-        fundingProjectException.checkPhase4Info(fundingProjectCreatePhase4RequestDto);
-        rewardExceptionInterface.rewardAmountCheck(rewardCreateRequestDtos);
-
+        fundingProejctExceptionInterface.checkPhase4Info(fundingProjectCreatePhase4RequestDto);
+        rewardExceptionInterface.checkRewardAmount(rewardCreateRequestDtos);
+        rewardExceptionInterface.checkRewardInfo(rewardCreateRequestDtos);
 
         // Redis로 4단계 정보들 저장
         FundingProjectCreatePhase4ResponseDto fundingProjectCreatePhase4ResponseDto = FundingProjectCreatePhase4ResponseDto.builder()
                 .memberId(memberId)
                 .deliveryCheck(fundingProjectCreatePhase4RequestDto.getDeliveryCheck())
-                .deliveryPrice(fundingProjectException.deliveryChecking(fundingProjectCreatePhase4RequestDto.getDeliveryCheck()))
+                .deliveryPrice(fundingProejctExceptionInterface.deliveryChecking(fundingProjectCreatePhase4RequestDto.getDeliveryCheck()))
                 .deliveryStartDate(fundingProjectCreatePhase4RequestDto.getDeliveryStartDate())
                 .build();
 
         // 이미 4단계 정보를 저장한 상태에서 다시 저장할 경우 기존 정보 삭제
-        if(phase4RedisRepository.findById(memberId).isPresent()){
+        if (phase4RedisRepository.findById(memberId).isPresent()) {
             phase4RedisRepository.deleteById(memberId);
         }
 
         phase4RedisRepository.save(fundingProjectCreatePhase4ResponseDto);
 
-
         List<RewardCreateResponseDto> rewardCreateResponseDtos = new ArrayList<>();
+
         // 리워드는 여러개를 생성할 수 있다.
-        for(RewardCreateRequestDto rewardCreateRequestDto : rewardCreateRequestDtos){
+        for (RewardCreateRequestDto rewardCreateRequestDto : rewardCreateRequestDtos) {
             // 다시 4단계 정보들을 input 하는 과정에서 리워드도 임시저장된 이전 정보가 존재한다면 삭제 처리
-            if(rewardRedisRepository.findById(memberId).isPresent()) {
+            if (rewardRedisRepository.findById(memberId).isPresent()) {
                 rewardRedisRepository.deleteById(memberId);
             }
 
@@ -234,7 +249,7 @@ public class FundingProjectService {
             String optionContent = "";
 
             // 리워드에 옵션이 필요할 경우 옵션 내용 추가
-            if(rewardCreateRequestDto.getRewardOptionOnOff().equals("O")){
+            if (rewardCreateRequestDto.getRewardOptionOnOff().equals("O")) {
                 optionContent = rewardCreateRequestDto.getOptionContent();
             }
 
@@ -249,9 +264,11 @@ public class FundingProjectService {
                     .optionContent(optionContent)
                     .build();
 
-            rewardRedisRepository.save(rewardCreateResponseDto);
+//            rewardRedisRepository.save(rewardCreateResponseDto);
             rewardCreateResponseDtos.add(rewardCreateResponseDto);
         }
+
+        rewards.put(authMember.getMemberId(), rewardCreateResponseDtos);
 
         HashMap<String, Object> resultSet = new HashMap<>();
         resultSet.put("createMessage", "펀딩 프로젝트 생성 4단계 완료!!!!");
@@ -261,8 +278,96 @@ public class FundingProjectService {
         return new ResponseEntity<>(new ResponseBody(StatusCode.OK, resultSet), HttpStatus.OK);
     }
 
-    // Gson().toJson("Json 객체 혹은 Dto 객체") -> Json 형식의 객체를 String 타입으로 변환
-    // Gson().fromJson("String 타입으로 변환된 객체", 변환될 Json 형식객체 혹은 DTO 객체.class) -> String 타입으로 변환된 Json 객체를 다시 Json 형식으로 변환
+
+    // 펀딩 프로젝트 생성 5단계 마지막
+    @Transactional
+    public ResponseEntity<ResponseBody> fundingCreateFinal(HttpServletRequest request) {
+
+        // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
+        memberExceptionInterface.checkHeaderToken(request);
+
+        // 인증받은 Member 객체 조회
+        Member authMember = jwtTokenProvider.getMemberFromAuthentication();
+        Long memberId = authMember.getMemberId();
+
+        // Redis로 관리되던 프로젝트 생성 정보들 조회
+        Optional<FundingProjectCreatePhase1ResponseDto> phase1 = phase1RedisRepository.findById(memberId);
+        Optional<FundingProjectCreatePhase2ResponseDto> phase2 = phase2RedisRepository.findById(memberId);
+        Optional<FundingProjectCreatePhase3ResponseDto> phase3 = phase3RedisRepository.findById(memberId);
+        Optional<FundingProjectCreatePhase4ResponseDto> phase4 = phase4RedisRepository.findById(memberId);
+
+        // static으로 저장되었던 Reward 객체 정보 조회
+        List<RewardCreateResponseDto> rewardsInfo = rewards.get(memberId);
+
+        // 프로젝트 종료일, 프로젝트 시작일, 배송 시작일을 날짜 형식으로 변환하여 반영
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        LocalDateTime endDate = LocalDateTime.parse(phase2.get().getEndDate(), formatter);
+        LocalDateTime deliveryStartDate = LocalDateTime.parse(phase4.get().getDeliveryStartDate(), formatter);
+        LocalDateTime startDate = LocalDateTime.parse(fundingProejctExceptionInterface.startDateSetting(phase3.get().getOpenReservation(), phase3.get().getOpenReservationStartDate()), formatter);
+
+        // FundingProject 객체에 실반영
+        FundingProject fundingProject = FundingProject.builder()
+                .projectCategory(ProjectCategory.findCategory(phase1.get().getProjectCategory()))
+                .projectType(ProjectType.findProjectType(phase1.get().getProjectType()))
+                .makerType(MakerType.findMakerType(phase1.get().getMakerType()))
+                .achievedAmount(phase1.get().getAchievedAmount())
+                .projectTitle(phase2.get().getProjectTitle())
+                .endDate(endDate)
+                .adultCheck(phase2.get().getAdultCheck())
+                .searchTag(phase2.get().getSearchTag())
+                .storyText(phase3.get().getStoryText())
+                .projectDescript(phase3.get().getProjectDescript())
+                .openReservation(phase3.get().getOpenReservation())
+                .startDate(startDate)
+                .deliveryCheck(phase4.get().getDeliveryCheck())
+                .deliveryPrice(phase4.get().getDeliveryPrice())
+                .deliveryStartDate(deliveryStartDate)
+                .progress("진행중")
+                .build();
+
+        fundingProjectRepository.save(fundingProject);
+
+        // Reward 객체에 실반영
+        for (RewardCreateResponseDto eachReward : rewardsInfo) {
+            Reward reward = Reward.builder()
+                    .rewardType(phase1.get().getRewardType())
+                    .rewardMakeType(RewardMakeType.findRewardMakeType(phase1.get().getRewardMakeType()))
+                    .rewardTitle(eachReward.getRewardTitle())
+                    .rewardAmount(eachReward.getRewardAmount())
+                    .rewardQuantity(eachReward.getRewardQuantity())
+                    .rewardContent(eachReward.getRewardContent())
+                    .fundingProject(fundingProject)
+                    .build();
+
+            rewardRepository.save(reward);
+
+            // Reward의 옵션이 존재할 경우 RewardOption 엔티티에 해당 정보 실반영
+            if (eachReward.getRewardOptionOnOff().equals("O")) {
+                RewardOption rewardOption = RewardOption.builder()
+                        .optionContent(eachReward.getOptionContent())
+                        .reward(reward)
+                        .build();
+
+                rewardOptionRepository.save(rewardOption);
+            }
+        }
+
+        // 업로드한 사진 및 비디오 미디어 자원들을 조회하여 해당 프로젝트의 아이디를 반영하여 연관짖기
+        List<Media> mediaList = dynamicQueryDsl.findMedias(fundingProject.getProjectTitle());
+        for (Media eachMedia : mediaList) {
+            dynamicQueryDsl.updateMedia(eachMedia, fundingProject.getFundingProjectId());
+        }
+
+        // 남아있는 임시저장된 Redis 객체들, 프로젝트 생성 정보들 삭제
+        phase1RedisRepository.deleteById(memberId);
+        phase2RedisRepository.deleteById(memberId);
+        phase3RedisRepository.deleteById(memberId);
+        phase4RedisRepository.deleteById(memberId);
+        // static 변수로 관리되던 Reward 객체 정보 삭제
+        rewards.remove(memberId);
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, "펀딩 프로젝트 생성 5단계 완료!!!!! 프로젝트 무사 생성을 축하드립니다!"), HttpStatus.OK);
+    }
 
 }
 

--- a/src/main/java/com/example/zzapdiz/reward/domain/Reward.java
+++ b/src/main/java/com/example/zzapdiz/reward/domain/Reward.java
@@ -1,11 +1,15 @@
 package com.example.zzapdiz.reward.domain;
 
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.rewardoption.RewardOption;
 import com.example.zzapdiz.share.project.RewardMakeType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -21,8 +25,7 @@ public class Reward {
     private String rewardType; // 리워드 유형
 
     @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private RewardMakeType rewardMakeType; // 리워드 제작 유형
+    private String rewardMakeType; // 리워드 제작 유형
 
     @Column(nullable = false)
     private String rewardTitle; // 리워드 명
@@ -35,4 +38,12 @@ public class Reward {
 
     @Column(nullable = false)
     private String rewardContent; // 리워드 내용
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fundingProjectId")
+    private FundingProject fundingProject;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "reward", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RewardOption> rewardOptions;
 }

--- a/src/main/java/com/example/zzapdiz/reward/repository/RewardRepository.java
+++ b/src/main/java/com/example/zzapdiz/reward/repository/RewardRepository.java
@@ -1,0 +1,7 @@
+package com.example.zzapdiz.reward.repository;
+
+import com.example.zzapdiz.reward.domain.Reward;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RewardRepository extends JpaRepository<Reward, Long> {
+}

--- a/src/main/java/com/example/zzapdiz/rewardoption/domain/RewardOption.java
+++ b/src/main/java/com/example/zzapdiz/rewardoption/domain/RewardOption.java
@@ -1,0 +1,29 @@
+package com.example.zzapdiz.rewardoption.domain;
+
+import com.example.zzapdiz.reward.domain.Reward;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@Entity
+public class RewardOption {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long rewardOptionid;
+
+    @Column(nullable = false)
+    private String optionContent;
+
+    @JoinColumn(name = "rewardId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Reward reward;
+
+}

--- a/src/main/java/com/example/zzapdiz/rewardoption/repository/RewardOptionRepository.java
+++ b/src/main/java/com/example/zzapdiz/rewardoption/repository/RewardOptionRepository.java
@@ -1,0 +1,9 @@
+package com.example.zzapdiz.rewardoption.repository;
+
+import com.example.zzapdiz.rewardoption.domain.RewardOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RewardOptionRepository extends JpaRepository<RewardOption, Long> {
+}

--- a/src/main/java/com/example/zzapdiz/share/StatusCode.java
+++ b/src/main/java/com/example/zzapdiz/share/StatusCode.java
@@ -21,7 +21,9 @@ public enum StatusCode {
     NOT_FOUND_MATCHING_PASSWORD(457, "비밀번호가 일치하지 않습니다."),
     UNAUTHORIZED_TOKEN(458, "유효한 토큰이 아닙니다."),
     EXIST_INCORRECTABLE_FUNDING_INFO(459, "펀딩 프로젝트 생성 기입 정보가 올바르지 않습니다."),
-    NEED_AMOUNT_CHECK(460, "리워드 수량 설정이 옳지 않습니다. 최소 50개 이상 설정이 필요합니다.");
+    NEED_AMOUNT_CHECK(460, "리워드 수량 설정이 옳지 않습니다. 최소 50개 이상 설정이 필요합니다."),
+    DUPLICATED_PROJECT_TITLE(461, "이미 존재하는 프로젝트 타이틀입니다."),
+    NEED_REWARD_INFO_CHECK(462, "리워드 정보가 올바르지 않습니다.");
 
 
 

--- a/src/main/java/com/example/zzapdiz/share/media/Media.java
+++ b/src/main/java/com/example/zzapdiz/share/media/Media.java
@@ -1,6 +1,5 @@
 package com.example.zzapdiz.share.media;
 
-import com.example.zzapdiz.fundingproject.domain.FundingProject;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,6 +35,9 @@ public class Media {
 
     @Column
     private Long fundingProjectId;
+
+    @Column(nullable = false)
+    private String projectTitle;
 
 //    @JoinColumn(name = "fundingProjectId", nullable = false)
 //    @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/zzapdiz/share/media/MediaUpload.java
+++ b/src/main/java/com/example/zzapdiz/share/media/MediaUpload.java
@@ -28,7 +28,7 @@ public class MediaUpload implements MediaUploadInterface {
     private final MediaRepository mediaRepository;
 
     @Override
-    public Media uploadMedia(MultipartFile media, String mediaPurpose) {
+    public void uploadMedia(MultipartFile media, String mediaPurpose, String projectTitle) {
 
         String mediaName = createFileName(media.getOriginalFilename()); // 각 파일의 이름을 저장
 
@@ -57,11 +57,10 @@ public class MediaUpload implements MediaUploadInterface {
                 .mediaType(media.getContentType())
                 .mediaUrl(mediaUrl)
                 .mediaPurpose(mediaPurpose)
+                .projectTitle(projectTitle)
                 .build();
 
         mediaRepository.save(uploadMedia);
-
-        return uploadMedia;
     }
 
     // S3에 저장되어있는 미디어 파일 삭제

--- a/src/main/java/com/example/zzapdiz/share/media/MediaUploadInterface.java
+++ b/src/main/java/com/example/zzapdiz/share/media/MediaUploadInterface.java
@@ -4,7 +4,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface MediaUploadInterface {
 
-    Media uploadMedia(MultipartFile media, String mediaPurpose);
+    void uploadMedia(MultipartFile media, String mediaPurpose, String projectTitle);
     void deleteFile(String fileName);
     String createFileName(String fileName);
     String getFileExtension(String fileName);

--- a/src/main/java/com/example/zzapdiz/share/project/MakerType.java
+++ b/src/main/java/com/example/zzapdiz/share/project/MakerType.java
@@ -12,4 +12,17 @@ public enum MakerType {
     CORPORATE_BUSINESS("법인 사업자");
 
     private String makerType;
+
+    public static String findMakerType(String makerType){
+        switch(makerType){
+            case "PERSONAL":
+                return MakerType.PERSONAL.makerType;
+            case "PERSONAL_BUSINESS":
+                return MakerType.PERSONAL_BUSINESS.makerType;
+            case "CORPORATE_BUSINESS":
+                return MakerType.CORPORATE_BUSINESS.makerType;
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/com/example/zzapdiz/share/project/ProjectCategory.java
+++ b/src/main/java/com/example/zzapdiz/share/project/ProjectCategory.java
@@ -18,4 +18,26 @@ public enum ProjectCategory {
 
     private String category;
 
+    public static String findCategory(String projectCatgory){
+        switch(projectCatgory){
+            case "TECH":
+                return ProjectCategory.TECH.category;
+            case "FOOD":
+                return ProjectCategory.FOOD.category;
+            case "HOME_LIVING":
+                return ProjectCategory.HOME_LIVING.category;
+            case "SPORTS_MOBILITY":
+                return ProjectCategory.SPORTS_MOBILITY.category;
+            case "CHARACTER_GOODS":
+                return ProjectCategory.CHARACTER_GOODS.category;
+            case "GAME_HOBBY":
+                return ProjectCategory.GAME_HOBBY.category;
+            case "CULTURE_ARTIST":
+                return ProjectCategory.CULTURE_ARTIST.category;
+            case "GROUP":
+                return ProjectCategory.GROUP.category;
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/com/example/zzapdiz/share/project/ProjectType.java
+++ b/src/main/java/com/example/zzapdiz/share/project/ProjectType.java
@@ -13,4 +13,18 @@ public enum ProjectType {
     SUCCESSED_PROJECT_REOPEN("와디즈에서 성공한 프로젝트 다시 공유");
 
     private String projectType;
+
+    public static String findProjectType(String projectType){
+        switch (projectType){
+            case "FIRST_OPEN":
+                return ProjectType.FIRST_OPEN.projectType;
+            case "REMAKE":
+                return ProjectType.REMAKE.projectType;
+            case "BROAD_SELL":
+                return ProjectType.BROAD_SELL.projectType;
+            case "SUCCESSED_PROJECT_REOPEN":
+                return ProjectType.SUCCESSED_PROJECT_REOPEN.projectType;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/example/zzapdiz/share/project/RewardMakeType.java
+++ b/src/main/java/com/example/zzapdiz/share/project/RewardMakeType.java
@@ -13,4 +13,18 @@ public enum RewardMakeType {
     GLOBAL("글로벌");
 
     private String rewardMakeType;
+
+    public static String findRewardMakeType(String rewardMakeType){
+        switch(rewardMakeType){
+            case "SELF_MADE":
+                return RewardMakeType.SELF_MADE.rewardMakeType;
+            case "CONSIGNMENT_MADE":
+                return RewardMakeType.CONSIGNMENT_MADE.rewardMakeType;
+            case "ODM":
+                return RewardMakeType.ODM.rewardMakeType;
+            case "GLOBAL":
+                return RewardMakeType.GLOBAL.rewardMakeType;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/example/zzapdiz/share/query/DynamicQueryDsl.java
+++ b/src/main/java/com/example/zzapdiz/share/query/DynamicQueryDsl.java
@@ -1,7 +1,9 @@
 package com.example.zzapdiz.share.query;
 
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
 import com.example.zzapdiz.member.domain.Member;
 import com.example.zzapdiz.member.request.MemberFindRequestDto;
+import com.example.zzapdiz.share.media.Media;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +14,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityManager;
 
+import java.util.List;
+
 import static com.example.zzapdiz.member.domain.QMember.member;
 import static com.example.zzapdiz.jwt.domain.QToken.token;
 import static com.example.zzapdiz.share.media.QMedia.media;
+import static com.example.zzapdiz.fundingproject.domain.QFundingProject.fundingProject;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -106,5 +111,30 @@ public class DynamicQueryDsl {
         entityManager.clear();
     }
 
+    /** 프로젝트에 속한 미디어들 조회 **/
+    public List<Media> findMedias(String projectTitle){
+        return jpaQueryFactory
+                .selectFrom(media)
+                .where(media.projectTitle.eq(projectTitle))
+                .fetch();
+    }
+
+    @Transactional
+    public void updateMedia(Media updateMedia, Long fundingProjectId){
+        jpaQueryFactory
+                .update(media)
+                .set(media.fundingProjectId, fundingProjectId)
+                .where(media.mediaId.eq(updateMedia.getMediaId()))
+                .execute();
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+//    public FundingProject findFundingProject(){
+//        return jpaQueryFactory
+//                .selectFrom(fundingProject)
+//                .where(fundingProject.)
+//    }
 
 }

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
@@ -47,7 +47,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
 public class FundingProjectConrollerTest {
 
     @InjectMocks
@@ -174,6 +173,28 @@ public class FundingProjectConrollerTest {
                 .andDo(print())
                 .andExpect(status().isOk());
 //                .andExpect(jsonPath("$.data.phase3Info.storyText").value(phase3RequestDto().getStoryText()));
+
+    }
+
+
+    @DisplayName("[FundingProjectController] 펀딩 프로젝트 생성 5단계 api")
+    @Test
+    void createFundingPhas5() throws Exception {
+        // given
+        doReturn(new ResponseEntity<>(new ResponseBody(StatusCode.OK, "펀딩 프로젝트 마지막 생성 완료"), HttpStatus.OK))
+                .when(fundingProjectService)
+                .fundingCreateFinal(any(MockHttpServletRequest.class));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post("/zzapdiz/funding/create/phase5")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .characterEncoding("utf-8"));
+
+        // then
+        ResultActions resultActionsThen = resultActions
+                .andDo(print())
+                .andExpect(status().isOk());
 
     }
 

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectServiceTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectServiceTest.java
@@ -25,6 +25,8 @@ import org.springframework.data.web.JsonPath;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +43,9 @@ public class FundingProjectServiceTest {
 
     @Mock
     private MemberException memberException;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
 
     @DisplayName("[FundingProjectService] 펀딩 프로젝트 생성 1단계 서비스")
     @Test
@@ -93,6 +98,28 @@ public class FundingProjectServiceTest {
         // then
         assertThat(statusCode).isEqualTo(200);
     }
+
+
+    @DisplayName("[FundingProjectService] 펀딩 프로젝트 생성 5단계 서비스")
+    @Test
+    void createFundingPhase5() {
+        // given
+        MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+
+        mockHttpServletRequest.addHeader("Authoization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ3bHN0cGduczUxQG5hdmVyLmNvbSIsImF1dGgiOiJVU0VSIiwiZXhwIjoxNjc5MzA4NDI2fQ.mTozdU7sMIVMmdMrfNQIfITSAtKuBQ7uaakDUGrIISI");
+        String token = mockHttpServletRequest.getHeader("Authorization");
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+
+        // when
+        int statusCode = fundingProjectService.fundingCreateFinal(mockHttpServletRequest).getBody().getStatusCode();
+
+        // then
+        assertThat(statusCode).isEqualTo(200);
+    }
+
 
     private FundingProjectCreatePhase1RequestDto phase1RequestDto(){
         return FundingProjectCreatePhase1RequestDto.builder()


### PR DESCRIPTION
[Feature/Funding/Create/Phase5]
- FundingProjectController 펀딩 프로젝트 생성 5단계 마지막 api 1차 구현
- FundingProjectService 펀딩 프로젝트 생성 5단계 비즈니스 로직 1차 구현
- Redis로 관리되던 프로젝트 생성 정보들 FundingProject, Reward, RewardOption, Media 엔티티에 실반영
- Reward 정보는 Redis 객체로 관리에서 static 타입의 변수로 설정하여 관리. (static이기 때문에 계속해서 메모리에 남아있지만 반영되는 즉시 삭제하도록 설정.) 
- FundingProjectExceptionInterface 업데이트
- RewardExceptionInterface 업데이트
- FundingProject 엔티티의 Enum 타입 속성들 String 타입으로 변경
- StatusCode 추가 업데이트
- 펀딩 프로젝트 생성 5단계 컨트롤러 테스트 업데이트
- 펀딩 프로젝트 생성 5단계 비즈니스 로직 서비스 테스트 업데이트