### PR TITLE
프로젝트 찜하기 api 1차 구현

### DIFF
--- a/src/main/java/com/example/zzapdiz/exception/pickproject/PickProjectException.java
+++ b/src/main/java/com/example/zzapdiz/exception/pickproject/PickProjectException.java
@@ -1,0 +1,32 @@
+package com.example.zzapdiz.exception.pickproject;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.member.domain.Member;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import static com.example.zzapdiz.fundingproject.domain.QFundingProject.fundingProject;
+
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class PickProjectException implements PickProjectExceptionInterface{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    // 본인이 생성한 프로젝트는 찜하기 불가
+    @Override
+    public Boolean pickMyProjectCheck(Member authMember, FundingProject project) {
+
+        if(jpaQueryFactory
+                .selectFrom(fundingProject)
+                .where(fundingProject.member.eq(authMember).and(fundingProject.fundingProjectId.eq(project.getFundingProjectId())))
+                .fetchOne() != null){
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/example/zzapdiz/exception/pickproject/PickProjectExceptionInterface.java
+++ b/src/main/java/com/example/zzapdiz/exception/pickproject/PickProjectExceptionInterface.java
@@ -1,0 +1,13 @@
+package com.example.zzapdiz.exception.pickproject;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.member.domain.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface PickProjectExceptionInterface {
+
+    /** 본인이 생성한 프로젝트는 찜할 수 없다. **/
+    Boolean pickMyProjectCheck(Member authMember, FundingProject project);
+
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
@@ -1,10 +1,8 @@
 package com.example.zzapdiz.fundingproject.domain;
 
+import com.example.zzapdiz.member.domain.Member;
+import com.example.zzapdiz.pickproject.domain.PickProject;
 import com.example.zzapdiz.reward.domain.Reward;
-import com.example.zzapdiz.share.media.Media;
-import com.example.zzapdiz.share.project.MakerType;
-import com.example.zzapdiz.share.project.ProjectCategory;
-import com.example.zzapdiz.share.project.ProjectType;
 import com.example.zzapdiz.share.Timestamped;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
@@ -13,7 +11,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -49,12 +46,6 @@ public class FundingProject extends Timestamped {
     @Column(nullable = false)
     private String storyText;
 
-//    @Column
-//    private String storyImage;
-//
-//    @Column
-//    private String storyVideo;
-
     @Column(nullable = false)
     private String projectDescript;
 
@@ -66,9 +57,6 @@ public class FundingProject extends Timestamped {
 
     @Column(nullable = false)
     private LocalDateTime endDate;
-
-//    @Column(nullable = false)
-//    private String thumbnailImage;
 
     @Column(nullable = false)
     private String makerType;
@@ -85,11 +73,15 @@ public class FundingProject extends Timestamped {
     @Column
     private LocalDateTime deliveryStartDate;
 
+    @JoinColumn(name = "memberId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
     @JsonIgnore
     @OneToMany(mappedBy = "fundingProject", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Reward> rewards;
 
-//    @OneToMany(mappedBy = "fundingProject", fetch = FetchType.LAZY,cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Media> medias;
-
+    @JsonIgnore
+    @OneToMany(mappedBy = "fundingProject")
+    private List<PickProject> pickProjects;
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
@@ -35,6 +35,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 import javax.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -322,6 +324,7 @@ public class FundingProjectService {
                 .deliveryPrice(phase4.get().getDeliveryPrice())
                 .deliveryStartDate(deliveryStartDate)
                 .progress("진행중")
+                .member(authMember)
                 .build();
 
         fundingProjectRepository.save(fundingProject);

--- a/src/main/java/com/example/zzapdiz/member/domain/Member.java
+++ b/src/main/java/com/example/zzapdiz/member/domain/Member.java
@@ -1,10 +1,14 @@
 package com.example.zzapdiz.member.domain;
 
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.pickproject.domain.PickProject;
 import com.example.zzapdiz.share.Timestamped;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.internal.util.stereotypes.Lazy;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -36,4 +40,14 @@ public class Member extends Timestamped {
     @ElementCollection(fetch = FetchType.EAGER)
     @Builder.Default
     private List<String> roles = new ArrayList<>();
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FundingProject> fundingProjects;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "member")
+    private List<PickProject> pickProjects;
+
+
 }

--- a/src/main/java/com/example/zzapdiz/member/service/MemberService.java
+++ b/src/main/java/com/example/zzapdiz/member/service/MemberService.java
@@ -45,7 +45,6 @@ public class MemberService {
     private final JwtTokenProvider jwtTokenProvider;
     private final DynamicQueryDsl dynamicQueryDsl;
     private final TokenRepository tokenRepository;
-    private final JPAQueryFactory jpaQueryFactory;
 
     // 회원가입
     public ResponseEntity<ResponseBody> memberSignUp(MemberSignupRequestDto memberSignupRequestDto) {

--- a/src/main/java/com/example/zzapdiz/pickproject/controller/PickProjectController.java
+++ b/src/main/java/com/example/zzapdiz/pickproject/controller/PickProjectController.java
@@ -1,0 +1,30 @@
+package com.example.zzapdiz.pickproject.controller;
+
+import com.example.zzapdiz.pickproject.service.PickProjectService;
+import com.example.zzapdiz.share.ResponseBody;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/zzapdiz")
+@RestController
+public class PickProjectController {
+
+    private final PickProjectService pickProjectService;
+
+    // 프로젝트 찜하기
+    @PostMapping("/project/pick/{projectId}")
+    public ResponseEntity<ResponseBody> pickProject(HttpServletRequest request, @PathVariable Long projectId){
+        log.info("프로젝트 찜하기 api : 요청자 - {}, 프로젝트 id - {}",request, projectId);
+
+        return pickProjectService.pickProject(request, projectId);
+    }
+}

--- a/src/main/java/com/example/zzapdiz/pickproject/domain/PickProject.java
+++ b/src/main/java/com/example/zzapdiz/pickproject/domain/PickProject.java
@@ -1,0 +1,31 @@
+package com.example.zzapdiz.pickproject.domain;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@Entity
+public class PickProject {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long pickProjectId;
+
+    @JoinColumn(name = "memberId")
+    @ManyToOne
+    private Member member;
+
+    @JoinColumn(name = "fundingProjectId")
+    @ManyToOne
+    private FundingProject fundingProject;
+
+}

--- a/src/main/java/com/example/zzapdiz/pickproject/repository/PickProjectRepository.java
+++ b/src/main/java/com/example/zzapdiz/pickproject/repository/PickProjectRepository.java
@@ -1,0 +1,9 @@
+package com.example.zzapdiz.pickproject.repository;
+
+import com.example.zzapdiz.pickproject.domain.PickProject;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PickProjectRepository extends JpaRepository<PickProject, Long> {
+}

--- a/src/main/java/com/example/zzapdiz/pickproject/response/PickProjectResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/pickproject/response/PickProjectResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.zzapdiz.pickproject.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PickProjectResponseDto {
+    private Long pickProjectId;
+    private Long memberId;
+    private Long fundingProjectId;
+}

--- a/src/main/java/com/example/zzapdiz/pickproject/service/PickProjectService.java
+++ b/src/main/java/com/example/zzapdiz/pickproject/service/PickProjectService.java
@@ -1,0 +1,81 @@
+package com.example.zzapdiz.pickproject.service;
+
+import com.example.zzapdiz.exception.member.MemberExceptionInterface;
+import com.example.zzapdiz.exception.pickproject.PickProjectException;
+import com.example.zzapdiz.exception.pickproject.PickProjectExceptionInterface;
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.jwt.JwtTokenProvider;
+import com.example.zzapdiz.member.domain.Member;
+import com.example.zzapdiz.pickproject.domain.PickProject;
+import com.example.zzapdiz.pickproject.repository.PickProjectRepository;
+import com.example.zzapdiz.pickproject.response.PickProjectResponseDto;
+import com.example.zzapdiz.share.ResponseBody;
+import com.example.zzapdiz.share.StatusCode;
+import com.example.zzapdiz.share.query.DynamicQueryDsl;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PickProjectService {
+
+    private final MemberExceptionInterface memberExceptionInterface;
+    private final PickProjectExceptionInterface pickProjectExceptionInterface;
+    private final DynamicQueryDsl dynamicQueryDsl;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PickProjectRepository pickProjectRepository;
+
+    // 프로젝트 찜하기
+    public ResponseEntity<ResponseBody> pickProject(HttpServletRequest request, Long projectId) {
+
+        // 유저 유효성 검증
+        memberExceptionInterface.checkHeaderToken(request);
+
+        // 찜하려는 유저의 정보와 찜하려는 프로젝트 조회
+        Member authMember = jwtTokenProvider.getMemberFromAuthentication();
+        FundingProject pickFundingProject = dynamicQueryDsl.getFundingProject(projectId);
+
+        // 본인이 생성한 프로젝트를 찜한 것인지 확인
+        if(pickProjectExceptionInterface.pickMyProjectCheck(authMember, pickFundingProject)){
+            return new ResponseEntity<>(new ResponseBody<>(StatusCode.CANT_PICK_MINE, null), HttpStatus.BAD_REQUEST);
+        }
+
+        // 이전에 같은 유저가 같은 프로젝트를 찜한 적이 있다면 찜 취소
+        if(dynamicQueryDsl.pickCancel(authMember, pickFundingProject)){
+            return new ResponseEntity<>(new ResponseBody(StatusCode.OK, "찜 취소!"), HttpStatus.OK);
+        }
+
+        // 찜하기 정보 실반영
+        PickProject pickProject = PickProject.builder()
+                .member(authMember)
+                .fundingProject(pickFundingProject)
+                .build();
+
+        pickProjectRepository.save(pickProject);
+
+        // 출력 결과 확인 HashMap
+        HashMap<String, Object> resultSet = new HashMap<>();
+        resultSet.put("pickMessage", "찜!");
+        resultSet.put("pickInfo", pickProjectResponseDto(pickProject));
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, resultSet), HttpStatus.OK);
+    }
+
+    // 결과 확인을 위한 Dto 객체 생성 함수
+    private PickProjectResponseDto pickProjectResponseDto(PickProject pickProject){
+
+        return PickProjectResponseDto.builder()
+                .pickProjectId(pickProject.getPickProjectId())
+                .memberId(pickProject.getMember().getMemberId())
+                .fundingProjectId(pickProject.getFundingProject().getFundingProjectId())
+                .build();
+    }
+}

--- a/src/main/java/com/example/zzapdiz/share/StatusCode.java
+++ b/src/main/java/com/example/zzapdiz/share/StatusCode.java
@@ -24,7 +24,8 @@ public enum StatusCode {
     NEED_AMOUNT_CHECK(460, "리워드 수량 설정이 옳지 않습니다. 최소 50개 이상 설정이 필요합니다."),
     DUPLICATED_PROJECT_TITLE(461, "이미 존재하는 프로젝트 타이틀입니다."),
     NEED_REWARD_INFO_CHECK(462, "리워드 정보가 올바르지 않습니다."),
-    TIME_LIMIT_CHECK(463, "일정 시간동안 프로젝트를 생성하지 않아 정보가 초기화되었습니다. 다시 단계 정보를 넣어주십시오.");
+    TIME_LIMIT_CHECK(463, "일정 시간동안 프로젝트를 생성하지 않아 정보가 초기화되었습니다. 다시 단계 정보를 넣어주십시오."),
+    CANT_PICK_MINE(464, "본인이 생성한 프로젝트는 찜하실 수 없습니다.");
 
 
 

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectServiceTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectServiceTest.java
@@ -10,20 +10,15 @@ import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase4Res
 import com.example.zzapdiz.fundingproject.service.FundingProjectService;
 import com.example.zzapdiz.jwt.JwtTokenProvider;
 import com.example.zzapdiz.member.request.MemberLoginRequestDto;
-import com.example.zzapdiz.member.service.MemberService;
 import com.example.zzapdiz.reward.request.RewardCreateRequestDto;
 import com.example.zzapdiz.reward.response.RewardCreateResponseDto;
 import com.google.gson.Gson;
-import io.jsonwebtoken.io.IOException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.web.JsonPath;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -31,7 +26,6 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
@@ -39,7 +33,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class FundingProjectServiceTest {

--- a/src/test/java/com/example/zzapdiz/pickproject/PickProjectControllerTest.java
+++ b/src/test/java/com/example/zzapdiz/pickproject/PickProjectControllerTest.java
@@ -1,0 +1,93 @@
+package com.example.zzapdiz.pickproject;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.fundingproject.repository.FundingProjectRepository;
+import com.example.zzapdiz.pickproject.controller.PickProjectController;
+import com.example.zzapdiz.pickproject.service.PickProjectService;
+import com.example.zzapdiz.share.ResponseBody;
+import com.example.zzapdiz.share.StatusCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import reactor.core.publisher.Sinks;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class PickProjectControllerTest {
+
+    @InjectMocks
+    private PickProjectController pickProjectController;
+
+    @Mock
+    private PickProjectService pickProjectService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void init() {
+        mockMvc = MockMvcBuilders.standaloneSetup(pickProjectController).build();
+    }
+
+
+    @DisplayName("[PickProjectController] 프로젝트 찜하기 api 컨트롤러 테스트")
+    @Test
+    void pickProjectTest() throws Exception {
+        // given
+        Mockito.doReturn(new ResponseEntity<>(new ResponseBody(StatusCode.OK, fakeProject()), HttpStatus.OK))
+                .when(pickProjectService)
+                .pickProject(any(MockHttpServletRequest.class), any(Long.class));
+
+        // when
+        ResultActions resultActionsWhen = mockMvc.perform(
+                MockMvcRequestBuilders.post("/zzapdiz/project/pick/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ3bHN0cGduczUyQG5hdmVyLmNvbSIsImF1dGgiOiJVU0VSIiwiZXhwIjoxNjc5NTc3NjU1fQ.WvNmFKTU3Bj8xjLa64fWzXnrFes4q5GljzO1ijFif8U")
+                        .characterEncoding("utf-8")
+        );
+
+        // then
+        ResultActions resultActionsThen = resultActionsWhen
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    private FundingProject fakeProject() {
+        return FundingProject.builder()
+                .fundingProjectId(1L)
+                .projectTitle("찜하기 테스트용 프로젝트명")
+                .projectCategory("전자/가전")
+                .projectType("손수 제작")
+                .achievedAmount(90000000)
+                .adultCheck("X")
+                .searchTag("#검색태그")
+                .storyText("프로젝트 스토리~~")
+                .projectDescript("프로젝트 요약 설명~~")
+                .openReservation("X")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now())
+                .makerType("개인")
+                .progress("진행중")
+                .deliveryCheck("X")
+                .build();
+    }
+}

--- a/src/test/java/com/example/zzapdiz/pickproject/PickProjectServiceTest.java
+++ b/src/test/java/com/example/zzapdiz/pickproject/PickProjectServiceTest.java
@@ -1,0 +1,106 @@
+package com.example.zzapdiz.pickproject;
+
+import com.example.zzapdiz.exception.member.MemberExceptionInterface;
+import com.example.zzapdiz.exception.pickproject.PickProjectExceptionInterface;
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.fundingproject.repository.FundingProjectRepository;
+import com.example.zzapdiz.jwt.JwtTokenProvider;
+import com.example.zzapdiz.member.domain.Member;
+import com.example.zzapdiz.member.repository.MemberRepository;
+import com.example.zzapdiz.pickproject.repository.PickProjectRepository;
+import com.example.zzapdiz.pickproject.service.PickProjectService;
+import com.example.zzapdiz.share.query.DynamicQueryDsl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class PickProjectServiceTest {
+
+    @InjectMocks
+    private PickProjectService pickProjectService;
+
+    @Mock
+    private PickProjectRepository pickProjectRepository;
+
+    @Mock
+    private FundingProjectRepository fundingProjectRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MemberExceptionInterface memberExceptionInterface;
+
+    @Mock
+    private PickProjectExceptionInterface pickProjectExceptionInterface;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private DynamicQueryDsl dynamicQueryDsl;
+
+    @DisplayName("[PickProjectService] 프로젝트 찜하기 서비스 테스트")
+    @Test
+    void pickProjectServiceTest(){
+        // given
+        fundingProjectRepository.save(fakeProject());
+
+        String token = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ3bHN0cGduczUyQG5hdmVyLmNvbSIsImF1dGgiOiJVU0VSIiwiZXhwIjoxNjc5NTc3NjU1fQ.WvNmFKTU3Bj8xjLa64fWzXnrFes4q5GljzO1ijFif8U";
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        memberRepository.save(jwtTokenProvider.getMemberFromAuthentication());
+
+        MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+        mockHttpServletRequest.addHeader("Authorization", token);
+        mockHttpServletRequest.addHeader("Refresh-Token", "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2Nzk1Nzc2NTV9.4jnPeM8K0mqjoj70SThCQ8sO2E7rAlALQLsZlBjvN8U");
+        // when
+        int statusCode = pickProjectService.pickProject(mockHttpServletRequest, 1L).getStatusCodeValue();
+
+        // then
+        assertThat(statusCode).isEqualTo(200);
+
+    }
+
+    private FundingProject fakeProject() {
+        return FundingProject.builder()
+                .fundingProjectId(1L)
+                .projectTitle("찜하기 테스트용 프로젝트명")
+                .projectCategory("전자/가전")
+                .projectType("손수 제작")
+                .achievedAmount(90000000)
+                .adultCheck("X")
+                .searchTag("#검색태그")
+                .storyText("프로젝트 스토리~~")
+                .projectDescript("프로젝트 요약 설명~~")
+                .openReservation("X")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now())
+                .makerType("개인")
+                .progress("진행중")
+                .deliveryCheck("X")
+                .build();
+    }
+
+    private Member authMember(){
+        return Member.builder()
+                .memberId(1L)
+                .email("wlstpgns51@naver.com")
+                .password("wls124578!")
+                .memberName("rltrlt")
+                .point(0)
+                .build();
+    }
+}


### PR DESCRIPTION
[Feature/Project/Pick]
- PickProjectController 프로젝트 찜하기 api 1차 구현
- PickProjectService 프로젝트 찜하기 api 비즈니스 로직 1차 구현
- PickProject 엔티티 생성
- PickProject 엔티티 데이터 관리를 위한 PickProjectRepository 생성
- 찜한 결과를 확인하기 위한 PickProjectResponseDto 객체 생성
- Member, FundingProject 엔티티에 PickProject 엔티티 연관관계 맺기
- PickProjectException 인터페이스 생성
- PickProjectException 인터페이스의 return 값을 boolean 타입으로 변형
- PickProjectController 테스트 코드 작성
- PickProjectService 테스트 코드 작성 보류