### PR TITLE
프로젝트 지지하기 api 1차 구현

### DIFF
--- a/src/main/java/com/example/zzapdiz/exception/supportproject/DoSupportException.java
+++ b/src/main/java/com/example/zzapdiz/exception/supportproject/DoSupportException.java
@@ -1,0 +1,28 @@
+package com.example.zzapdiz.exception.supportproject;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.member.domain.Member;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.example.zzapdiz.fundingproject.domain.QFundingProject.fundingProject;
+
+@RequiredArgsConstructor
+@Component
+public class DoSupportException implements DoSupportExceptionInterface{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Boolean supportMyProjectCheck(Member authMember, FundingProject project) {
+        if(jpaQueryFactory
+                .selectFrom(fundingProject)
+                .where(fundingProject.member.eq(authMember).and(fundingProject.fundingProjectId.eq(project.getFundingProjectId())))
+                .fetchOne() != null){
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/example/zzapdiz/exception/supportproject/DoSupportExceptionInterface.java
+++ b/src/main/java/com/example/zzapdiz/exception/supportproject/DoSupportExceptionInterface.java
@@ -1,0 +1,12 @@
+package com.example.zzapdiz.exception.supportproject;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.member.domain.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface DoSupportExceptionInterface {
+
+    /** 본인이 생성한 프로젝트를 지지한 것인지 확인 **/
+    Boolean supportMyProjectCheck(Member authMember, FundingProject project);
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
@@ -4,6 +4,7 @@ import com.example.zzapdiz.member.domain.Member;
 import com.example.zzapdiz.pickproject.domain.PickProject;
 import com.example.zzapdiz.reward.domain.Reward;
 import com.example.zzapdiz.share.Timestamped;
+import com.example.zzapdiz.supportproject.domain.DoSupport;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -84,4 +85,8 @@ public class FundingProject extends Timestamped {
     @JsonIgnore
     @OneToMany(mappedBy = "fundingProject")
     private List<PickProject> pickProjects;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "fundingProject")
+    private List<DoSupport> doSupports;
 }

--- a/src/main/java/com/example/zzapdiz/member/domain/Member.java
+++ b/src/main/java/com/example/zzapdiz/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.example.zzapdiz.member.domain;
 import com.example.zzapdiz.fundingproject.domain.FundingProject;
 import com.example.zzapdiz.pickproject.domain.PickProject;
 import com.example.zzapdiz.share.Timestamped;
+import com.example.zzapdiz.supportproject.domain.DoSupport;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,6 +49,10 @@ public class Member extends Timestamped {
     @JsonIgnore
     @OneToMany(mappedBy = "member")
     private List<PickProject> pickProjects;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "member")
+    private List<DoSupport> doSupports;
 
 
 }

--- a/src/main/java/com/example/zzapdiz/share/StatusCode.java
+++ b/src/main/java/com/example/zzapdiz/share/StatusCode.java
@@ -25,7 +25,8 @@ public enum StatusCode {
     DUPLICATED_PROJECT_TITLE(461, "이미 존재하는 프로젝트 타이틀입니다."),
     NEED_REWARD_INFO_CHECK(462, "리워드 정보가 올바르지 않습니다."),
     TIME_LIMIT_CHECK(463, "일정 시간동안 프로젝트를 생성하지 않아 정보가 초기화되었습니다. 다시 단계 정보를 넣어주십시오."),
-    CANT_PICK_MINE(464, "본인이 생성한 프로젝트는 찜하실 수 없습니다.");
+    CANT_PICK_MINE(464, "본인이 생성한 프로젝트는 찜하실 수 없습니다."),
+    CANT_SUPPORT_MINE(465, "본인이 생성한 프로젝트는 지지하실 수 없습니다.");
 
 
 

--- a/src/main/java/com/example/zzapdiz/share/query/DynamicQueryDsl.java
+++ b/src/main/java/com/example/zzapdiz/share/query/DynamicQueryDsl.java
@@ -3,15 +3,11 @@ package com.example.zzapdiz.share.query;
 import com.example.zzapdiz.fundingproject.domain.FundingProject;
 import com.example.zzapdiz.member.domain.Member;
 import com.example.zzapdiz.member.request.MemberFindRequestDto;
-import com.example.zzapdiz.share.ResponseBody;
-import com.example.zzapdiz.share.StatusCode;
 import com.example.zzapdiz.share.media.Media;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,6 +21,7 @@ import static com.example.zzapdiz.jwt.domain.QToken.token;
 import static com.example.zzapdiz.share.media.QMedia.media;
 import static com.example.zzapdiz.fundingproject.domain.QFundingProject.fundingProject;
 import static com.example.zzapdiz.pickproject.domain.QPickProject.pickProject;
+import static com.example.zzapdiz.supportproject.domain.QDoSupport.doSupport;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -157,6 +154,28 @@ public class DynamicQueryDsl {
             jpaQueryFactory
                     .delete(pickProject)
                     .where(pickProject.member.eq(authMember).and(pickProject.fundingProject.eq(project)))
+                    .execute();
+
+            entityManager.flush();
+            entityManager.clear();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /** 지지하기 두번 활성화 시 취소 **/
+    @Transactional
+    public Boolean supportCancel(Member authMember, FundingProject project){
+
+        if(jpaQueryFactory
+                .selectFrom(doSupport)
+                .where(doSupport.member.eq(authMember).and(doSupport.fundingProject.eq(project)))
+                .fetchOne() != null){
+            jpaQueryFactory
+                    .delete(doSupport)
+                    .where(doSupport.member.eq(authMember).and(doSupport.fundingProject.eq(project)))
                     .execute();
 
             entityManager.flush();

--- a/src/main/java/com/example/zzapdiz/supportproject/controller/DoSupportController.java
+++ b/src/main/java/com/example/zzapdiz/supportproject/controller/DoSupportController.java
@@ -1,0 +1,30 @@
+package com.example.zzapdiz.supportproject.controller;
+
+import com.example.zzapdiz.share.ResponseBody;
+import com.example.zzapdiz.supportproject.service.DoSupportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/zzapdiz")
+@RestController
+public class DoSupportController {
+
+    private final DoSupportService doSupportService;
+
+    // 프로젝트 지지하기
+    @PostMapping("/project/support/{projectId}")
+    public ResponseEntity<ResponseBody> supportProject(HttpServletRequest request, @PathVariable Long projectId){
+        log.info("프로젝트 지지하기 api : 요청자 - {}, 프로젝트 ID - {}", request, projectId);
+
+        return doSupportService.supportProject(request, projectId);
+    }
+}

--- a/src/main/java/com/example/zzapdiz/supportproject/domain/DoSupport.java
+++ b/src/main/java/com/example/zzapdiz/supportproject/domain/DoSupport.java
@@ -1,0 +1,30 @@
+package com.example.zzapdiz.supportproject.domain;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@Entity
+public class DoSupport {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long doSupportId;
+
+    @JoinColumn(name = "memberId")
+    @ManyToOne
+    private Member member;
+
+    @JoinColumn(name = "fundingProjectId")
+    @ManyToOne
+    private FundingProject fundingProject;
+}

--- a/src/main/java/com/example/zzapdiz/supportproject/repository/DoSupportRepository.java
+++ b/src/main/java/com/example/zzapdiz/supportproject/repository/DoSupportRepository.java
@@ -1,0 +1,9 @@
+package com.example.zzapdiz.supportproject.repository;
+
+import com.example.zzapdiz.supportproject.domain.DoSupport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DoSupportRepository extends JpaRepository<DoSupport, Long> {
+}

--- a/src/main/java/com/example/zzapdiz/supportproject/response/DoSupportResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/supportproject/response/DoSupportResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.zzapdiz.supportproject.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DoSupportResponseDto {
+    private Long doSupportId;
+    private Long memberId;
+    private Long fundingProjectId;
+}

--- a/src/main/java/com/example/zzapdiz/supportproject/service/DoSupportService.java
+++ b/src/main/java/com/example/zzapdiz/supportproject/service/DoSupportService.java
@@ -1,0 +1,76 @@
+package com.example.zzapdiz.supportproject.service;
+
+import com.example.zzapdiz.exception.member.MemberExceptionInterface;
+import com.example.zzapdiz.exception.supportproject.DoSupportExceptionInterface;
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.jwt.JwtTokenProvider;
+import com.example.zzapdiz.member.domain.Member;
+import com.example.zzapdiz.share.ResponseBody;
+import com.example.zzapdiz.share.StatusCode;
+import com.example.zzapdiz.share.query.DynamicQueryDsl;
+import com.example.zzapdiz.supportproject.domain.DoSupport;
+import com.example.zzapdiz.supportproject.repository.DoSupportRepository;
+import com.example.zzapdiz.supportproject.response.DoSupportResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+
+@RequiredArgsConstructor
+@Service
+public class DoSupportService {
+
+    private final MemberExceptionInterface memberExceptionInterface;
+    private final DoSupportExceptionInterface doSupportExceptionInterface;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final DynamicQueryDsl dynamicQueryDsl;
+    private final DoSupportRepository doSupportRepository;
+
+    // 프로젝트 지지하기
+    public ResponseEntity<ResponseBody> supportProject(HttpServletRequest request, Long projectId){
+
+        // 유저 유효성 검증
+        if(memberExceptionInterface.checkHeaderToken(request)){
+            return new ResponseEntity<>(new ResponseBody(StatusCode.UNAUTHORIZED_TOKEN, null), HttpStatus.BAD_REQUEST);
+        }
+
+        // 지지하고자 하는 유저의 정보 조회 + 지지하고자 하는 프로젝트 정보 조회
+        Member authMember = jwtTokenProvider.getMemberFromAuthentication();
+        FundingProject supportProject = dynamicQueryDsl.getFundingProject(projectId);
+
+        // 본인이 생성한 프로젝트는 지지할 수 없음을 확인
+        if(doSupportExceptionInterface.supportMyProjectCheck(authMember, supportProject)){
+            return new ResponseEntity<>(new ResponseBody(StatusCode.CANT_SUPPORT_MINE, null), HttpStatus.BAD_REQUEST);
+        }
+
+        // 지지를 이미 한 번 했으면 취소로 처리
+        if (dynamicQueryDsl.supportCancel(authMember, supportProject)) {
+            return new ResponseEntity<>(new ResponseBody(StatusCode.OK, "지지 취소!"), HttpStatus.OK);
+        }
+
+        // 지지하기 정보 실반영
+        DoSupport doSupport = DoSupport.builder()
+                .member(authMember)
+                .fundingProject(supportProject)
+                .build();
+
+        doSupportRepository.save(doSupport);
+
+        HashMap<String, Object> resultSet = new HashMap<>();
+        resultSet.put("supportMessage", "지지!");
+        resultSet.put("supportInfo", doSupportResponseDto(doSupport));
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, resultSet), HttpStatus.OK);
+    }
+
+    private DoSupportResponseDto doSupportResponseDto(DoSupport doSupport){
+        return DoSupportResponseDto.builder()
+                .doSupportId(doSupport.getDoSupportId())
+                .memberId(doSupport.getMember().getMemberId())
+                .fundingProjectId(doSupport.getFundingProject().getFundingProjectId())
+                .build();
+    }
+}

--- a/src/test/java/com/example/zzapdiz/pickproject/PickProjectServiceTest.java
+++ b/src/test/java/com/example/zzapdiz/pickproject/PickProjectServiceTest.java
@@ -66,6 +66,7 @@ public class PickProjectServiceTest {
         MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
         mockHttpServletRequest.addHeader("Authorization", token);
         mockHttpServletRequest.addHeader("Refresh-Token", "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2Nzk1Nzc2NTV9.4jnPeM8K0mqjoj70SThCQ8sO2E7rAlALQLsZlBjvN8U");
+
         // when
         int statusCode = pickProjectService.pickProject(mockHttpServletRequest, 1L).getStatusCodeValue();
 

--- a/src/test/java/com/example/zzapdiz/supportproject/DoSupportControllerTest.java
+++ b/src/test/java/com/example/zzapdiz/supportproject/DoSupportControllerTest.java
@@ -1,0 +1,89 @@
+package com.example.zzapdiz.supportproject;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.share.ResponseBody;
+import com.example.zzapdiz.share.StatusCode;
+import com.example.zzapdiz.supportproject.controller.DoSupportController;
+import com.example.zzapdiz.supportproject.service.DoSupportService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class DoSupportControllerTest {
+
+    @InjectMocks
+    private DoSupportController doSupportController;
+
+    @Mock
+    private DoSupportService doSupportService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void init() {
+        mockMvc = MockMvcBuilders.standaloneSetup(doSupportController).build();
+    }
+
+    @DisplayName("[DoSupportController] 프로젝트 지지하기 api 컨트롤러 테스트")
+    @Test
+    void supportProjectTest() throws Exception{
+        // given
+        Mockito.doReturn(new ResponseEntity<>(new ResponseBody(StatusCode.OK, fakeProject()), HttpStatus.OK))
+                .when(doSupportService)
+                .supportProject(any(MockHttpServletRequest.class), any(Long.class));
+
+        // when
+        ResultActions resultActionsWhen = mockMvc.perform(
+                MockMvcRequestBuilders.post("/zzapdiz/project/support/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ3bHN0cGduczUyQG5hdmVyLmNvbSIsImF1dGgiOiJVU0VSIiwiZXhwIjoxNjc5NTc3NjU1fQ.WvNmFKTU3Bj8xjLa64fWzXnrFes4q5GljzO1ijFif8U")
+                        .characterEncoding("utf-8")
+        );
+
+        // then
+        resultActionsWhen
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    private FundingProject fakeProject() {
+        return FundingProject.builder()
+                .fundingProjectId(1L)
+                .projectTitle("지지하기 테스트용 프로젝트명")
+                .projectCategory("전자/가전")
+                .projectType("손수 제작")
+                .achievedAmount(90000000)
+                .adultCheck("X")
+                .searchTag("#검색태그")
+                .storyText("프로젝트 스토리~~")
+                .projectDescript("프로젝트 요약 설명~~")
+                .openReservation("X")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now())
+                .makerType("개인")
+                .progress("진행중")
+                .deliveryCheck("X")
+                .build();
+    }
+}

--- a/src/test/java/com/example/zzapdiz/supportproject/DoSuppportServiceTest.java
+++ b/src/test/java/com/example/zzapdiz/supportproject/DoSuppportServiceTest.java
@@ -1,0 +1,124 @@
+package com.example.zzapdiz.supportproject;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.fundingproject.repository.FundingProjectRepository;
+import com.example.zzapdiz.jwt.JwtTokenProvider;
+import com.example.zzapdiz.jwt.dto.TokenDto;
+import com.example.zzapdiz.member.domain.Member;
+import com.example.zzapdiz.member.repository.MemberRepository;
+import com.example.zzapdiz.supportproject.repository.DoSupportRepository;
+import com.example.zzapdiz.supportproject.service.DoSupportService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class DoSuppportServiceTest {
+
+    @InjectMocks
+    private DoSupportService doSupportService;
+
+    @Mock
+    private DoSupportRepository doSupportRepository;
+
+    @Mock
+    private FundingProjectRepository fundingProjectRepository;
+
+    @Mock
+    private AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private AtomicBoolean atomicBoolean;
+
+
+    @DisplayName("[DoSupportService] 프로젝트 지지하기 api 서비스 테스트")
+    @Test
+    void supportProjectserviceTest() throws IOException, ServletException {
+        // given
+        memberRepository.save(authMember());
+        fundingProjectRepository.save(fakeProject(authMember()));
+
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(authMember().getEmail(), authMember().getPassword());
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        TokenDto tokenDto = jwtTokenProvider.generateToken(authentication);
+
+        // Response Header에 액세스 토큰 리프레시 토큰, 토큰 만료일 input
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        mockHttpServletResponse.addHeader("Authorization", "Bearer " + tokenDto.getAccessToken());
+        mockHttpServletResponse.addHeader("Refresh-Token", tokenDto.getRefreshToken());
+        mockHttpServletResponse.addHeader("Access-Token-Expire-Time", tokenDto.getAccessTokenExpiresIn().toString());
+
+        String token = tokenDto.getAccessToken();
+
+        authentication = jwtTokenProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+
+        MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+        mockHttpServletRequest.authenticate(mockHttpServletResponse);
+//        mockHttpServletRequest.addHeader("Authirization", token);
+//        mockHttpServletRequest.addHeader("Refresh-Token", "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2Nzk1Nzc2NTV9.4jnPeM8K0mqjoj70SThCQ8sO2E7rAlALQLsZlBjvN8U");
+
+
+        // when
+        int statusCode = doSupportService.supportProject(mockHttpServletRequest, 1L).getStatusCodeValue();
+
+        // then
+        assertThat(statusCode).isEqualTo(200);
+
+    }
+
+    private FundingProject fakeProject(Member authMember) {
+        return FundingProject.builder()
+                .fundingProjectId(1L)
+                .projectTitle("찜하기 테스트용 프로젝트명")
+                .projectCategory("전자/가전")
+                .projectType("손수 제작")
+                .achievedAmount(90000000)
+                .adultCheck("X")
+                .searchTag("#검색태그")
+                .storyText("프로젝트 스토리~~")
+                .projectDescript("프로젝트 요약 설명~~")
+                .openReservation("X")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now())
+                .makerType("개인")
+                .progress("진행중")
+                .deliveryCheck("X")
+                .member(authMember)
+                .build();
+    }
+
+
+    private Member authMember(){
+        return Member.builder()
+                .memberId(1L)
+                .email("wlstpgns51@naver.com")
+                .password("wls124578!")
+                .memberName("rltrlt")
+                .point(0)
+                .build();
+    }
+}


### PR DESCRIPTION
[Feature/Project/Support]
- DoSupportController 프로젝트 지지하기 api 1차 구현
- DoSupportService 프로젝트 지지하기 api 비즈니스 로직 1차 구현
- DoSupport 엔티티 생성
- DoSupport 엔티티 관리를 위한 DoSupportRepository 생성
- 지지하기 결과 확인을 위한 DoSupportResponseDto 객체 생성
- DoSupportException 인터페이스 생성 및 업데이트
- DynamicQueryDsl 지지하기 취소 함수 생성
- StatusCode 상태 코드 업데이트
- DoSupportController 테스트 코드 작성
- DoSupportService 테스트 코드 작성 보류