### PR TITLE
펀딩 프로젝트 조회 api 1차 구현

### DIFF
--- a/src/main/java/com/example/zzapdiz/configuration/MySqlCustomTemplate.java
+++ b/src/main/java/com/example/zzapdiz/configuration/MySqlCustomTemplate.java
@@ -1,0 +1,17 @@
+package com.example.zzapdiz.configuration;
+
+import com.querydsl.core.types.Ops;
+import com.querydsl.jpa.JPQLTemplates;
+
+public class MySqlCustomTemplate extends JPQLTemplates {
+
+    public MySqlCustomTemplate(){
+        this(DEFAULT_ESCAPE);
+        add(Ops.MathOps.RANDOM, "random()");
+        add(Ops.MathOps.RANDOM2, "random({0})");
+    }
+
+    private MySqlCustomTemplate(char escape){
+        super(escape);
+    }
+}

--- a/src/main/java/com/example/zzapdiz/configuration/QuerydslConfig.java
+++ b/src/main/java/com/example/zzapdiz/configuration/QuerydslConfig.java
@@ -10,7 +10,6 @@ import javax.persistence.EntityManager;
 
 @Slf4j
 @Configuration
-@RequiredArgsConstructor
 public class QuerydslConfig {
 
     @Bean

--- a/src/main/java/com/example/zzapdiz/configuration/SecurityConfig.java
+++ b/src/main/java/com/example/zzapdiz/configuration/SecurityConfig.java
@@ -33,7 +33,9 @@ public class SecurityConfig {
                         "/assets/**").permitAll()
                 .antMatchers("/zzapdiz/member/signup",
                         "/zzapdiz/member/login",
-                        "/zzapdiz/member/findid").permitAll()
+                        "/zzapdiz/member/findid",
+                        "/zzapdiz/funding/read/**",
+                        "/zzapdiz/funding/readlist/**").permitAll()
                 .antMatchers("/test").hasRole("USER")
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
@@ -88,4 +88,12 @@ public class FundingProjectController {
 
         return fundingProjectService.rewardDelete(request, rewardNo);
     }
+
+    /** 펀딩 프로젝트 조회 **/
+    @GetMapping("/funding/read/{projectId}")
+    public ResponseEntity<ResponseBody> fundingProjectRead(@PathVariable Long projectId){
+        log.info("펀딩 프로젝트 조회 api : 프로젝트 - {}", projectId);
+
+        return fundingProjectService.fundingProjectRead(projectId);
+    }
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
@@ -19,6 +19,7 @@ import java.util.List;
 @AllArgsConstructor
 @Getter
 @Builder
+@Table(indexes = {@Index(name = "indexId", columnList = "fundingProjectId")})
 @Entity
 public class FundingProject extends Timestamped {
 
@@ -74,6 +75,7 @@ public class FundingProject extends Timestamped {
     @Column
     private LocalDateTime deliveryStartDate;
 
+    @JsonIgnore
     @JoinColumn(name = "memberId")
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;

--- a/src/main/java/com/example/zzapdiz/fundingproject/response/ProjectReadResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/response/ProjectReadResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.zzapdiz.fundingproject.response;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.reward.domain.Reward;
+import com.example.zzapdiz.share.media.Media;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class ProjectReadResponseDto {
+    private FundingProject fundingProject;
+    private String remainDate;
+    private String makerName;
+    private List<Reward> rewards;
+    private List<Media> medias;
+    private Long countPick;
+    private Long countSupport;
+    private List<FundingProject> similarProjects;
+    private List<FundingProject> makersOtherProjects;
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
@@ -6,10 +6,7 @@ import com.example.zzapdiz.exception.reward.RewardExceptionInterface;
 import com.example.zzapdiz.fundingproject.domain.FundingProject;
 import com.example.zzapdiz.fundingproject.repository.*;
 import com.example.zzapdiz.fundingproject.request.*;
-import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase1ResponseDto;
-import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase2ResponseDto;
-import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase3ResponseDto;
-import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase4ResponseDto;
+import com.example.zzapdiz.fundingproject.response.*;
 import com.example.zzapdiz.jwt.JwtTokenProvider;
 import com.example.zzapdiz.member.domain.Member;
 import com.example.zzapdiz.reward.domain.Reward;
@@ -35,8 +32,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
 import javax.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -76,11 +71,11 @@ public class FundingProjectService {
         Long memberId = jwtTokenProvider.getMemberFromAuthentication().getMemberId();
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
-        if(memberExceptionInterface.checkHeaderToken(request)){
+        if (memberExceptionInterface.checkHeaderToken(request)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.UNAUTHORIZED_TOKEN, null), HttpStatus.BAD_REQUEST);
         }
         // 1단계 정보들 확인
-        if(fundingProejctExceptionInterface.checkPhase1Info(fundingProjectCreatePhase1RequestDt0)){
+        if (fundingProejctExceptionInterface.checkPhase1Info(fundingProjectCreatePhase1RequestDt0)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.EXIST_INCORRECTABLE_FUNDING_INFO, null), HttpStatus.BAD_REQUEST);
         }
 
@@ -121,14 +116,14 @@ public class FundingProjectService {
         Long memberId = jwtTokenProvider.getMemberFromAuthentication().getMemberId();
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
-        if(memberExceptionInterface.checkHeaderToken(request)){
+        if (memberExceptionInterface.checkHeaderToken(request)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.UNAUTHORIZED_TOKEN, null), HttpStatus.BAD_REQUEST);
         }
         // 2단계 정보 확인
-        if(fundingProejctExceptionInterface.checkPhase2Info(fundingProjectCreatePhase2RequestDto, thumbnailImage)){
+        if (fundingProejctExceptionInterface.checkPhase2Info(fundingProjectCreatePhase2RequestDto, thumbnailImage)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.EXIST_INCORRECTABLE_FUNDING_INFO, null), HttpStatus.BAD_REQUEST);
         }
-        if(fundingProejctExceptionInterface.checkDuplicatedTitle(fundingProjectCreatePhase2RequestDto.getProjectTitle())){
+        if (fundingProejctExceptionInterface.checkDuplicatedTitle(fundingProjectCreatePhase2RequestDto.getProjectTitle())) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.DUPLICATED_PROJECT_TITLE, null), HttpStatus.OK);
         }
 
@@ -172,11 +167,11 @@ public class FundingProjectService {
         Long memberId = jwtTokenProvider.getMemberFromAuthentication().getMemberId();
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
-        if(memberExceptionInterface.checkHeaderToken(request)){
+        if (memberExceptionInterface.checkHeaderToken(request)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.UNAUTHORIZED_TOKEN, null), HttpStatus.BAD_REQUEST);
         }
         // 펀딩 프로젝트 3단계 기입 정보들 확인
-        if(fundingProejctExceptionInterface.checkPhase3Info(fundingProjectCreatePhase3RequestDto, videoAndImages)){
+        if (fundingProejctExceptionInterface.checkPhase3Info(fundingProjectCreatePhase3RequestDto, videoAndImages)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.EXIST_INCORRECTABLE_FUNDING_INFO, null), HttpStatus.BAD_REQUEST);
         }
 
@@ -226,17 +221,17 @@ public class FundingProjectService {
         Long memberId = jwtTokenProvider.getMemberFromAuthentication().getMemberId();
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
-        if(memberExceptionInterface.checkHeaderToken(request)){
+        if (memberExceptionInterface.checkHeaderToken(request)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.UNAUTHORIZED_TOKEN, null), HttpStatus.BAD_REQUEST);
         }
         // 펀딩 프로젝트 4단계 기입 정보들 확인
-        if(fundingProejctExceptionInterface.checkPhase4Info(fundingProjectCreatePhase4RequestDto)){
+        if (fundingProejctExceptionInterface.checkPhase4Info(fundingProjectCreatePhase4RequestDto)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.EXIST_INCORRECTABLE_FUNDING_INFO, null), HttpStatus.BAD_REQUEST);
         }
-        if(rewardExceptionInterface.checkRewardAmount(rewardCreateRequestDtos)){
+        if (rewardExceptionInterface.checkRewardAmount(rewardCreateRequestDtos)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.NEED_AMOUNT_CHECK, null), HttpStatus.BAD_REQUEST);
         }
-        if(rewardExceptionInterface.checkRewardInfo(rewardCreateRequestDtos)){
+        if (rewardExceptionInterface.checkRewardInfo(rewardCreateRequestDtos)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.NEED_REWARD_INFO_CHECK, null), HttpStatus.BAD_REQUEST);
         }
 
@@ -305,7 +300,7 @@ public class FundingProjectService {
     public ResponseEntity<ResponseBody> fundingCreateFinal(HttpServletRequest request) {
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
-        if(memberExceptionInterface.checkHeaderToken(request)){
+        if (memberExceptionInterface.checkHeaderToken(request)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.UNAUTHORIZED_TOKEN, null), HttpStatus.BAD_REQUEST);
         }
 
@@ -319,7 +314,7 @@ public class FundingProjectService {
         Optional<FundingProjectCreatePhase3ResponseDto> phase3 = phase3RedisRepository.findById(memberId);
         Optional<FundingProjectCreatePhase4ResponseDto> phase4 = phase4RedisRepository.findById(memberId);
 
-        if(fundingProejctExceptionInterface.checkAllPhase(phase1, phase2, phase3, phase4)){
+        if (fundingProejctExceptionInterface.checkAllPhase(phase1, phase2, phase3, phase4)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.TIME_LIMIT_CHECK, null), HttpStatus.BAD_REQUEST);
         }
 
@@ -403,7 +398,7 @@ public class FundingProjectService {
             HttpServletRequest request, FundingRewardUpdateRequestDto rewardUpdateRequestDto) {
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
-        if(memberExceptionInterface.checkHeaderToken(request)){
+        if (memberExceptionInterface.checkHeaderToken(request)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.UNAUTHORIZED_TOKEN, null), HttpStatus.BAD_REQUEST);
         }
 
@@ -411,8 +406,8 @@ public class FundingProjectService {
 
         List<RewardCreateResponseDto> rewardInfo = rewards.get(authMember.getMemberId());
 
-        for(RewardCreateResponseDto reward : rewardInfo){
-            if(reward.getNo() == rewardUpdateRequestDto.getNo()){
+        for (RewardCreateResponseDto reward : rewardInfo) {
+            if (reward.getNo() == rewardUpdateRequestDto.getNo()) {
                 reward.setRewardTitle(rewardUpdateRequestDto.getRewardTitle());
                 reward.setRewardAmount(rewardUpdateRequestDto.getRewardAmount());
                 reward.setRewardQuantity(rewardUpdateRequestDto.getRewardQuantity());
@@ -429,10 +424,10 @@ public class FundingProjectService {
 
 
     // 생성 중인 리워드 삭제
-    public ResponseEntity<ResponseBody> rewardDelete(HttpServletRequest request, int rewardNo){
+    public ResponseEntity<ResponseBody> rewardDelete(HttpServletRequest request, int rewardNo) {
 
         // 펀딩 프로젝트 생성 요청 회원의 토큰 유효성 검증
-        if(memberExceptionInterface.checkHeaderToken(request)){
+        if (memberExceptionInterface.checkHeaderToken(request)) {
             return new ResponseEntity<>(new ResponseBody(StatusCode.UNAUTHORIZED_TOKEN, null), HttpStatus.BAD_REQUEST);
         }
 
@@ -440,8 +435,8 @@ public class FundingProjectService {
 
         List<RewardCreateResponseDto> rewardInfo = rewards.get(authMember.getMemberId());
 
-        for(RewardCreateResponseDto reward : rewardInfo){
-            if(reward.getNo() == rewardNo){
+        for (RewardCreateResponseDto reward : rewardInfo) {
+            if (reward.getNo() == rewardNo) {
                 rewardInfo.remove(rewardNo);
             }
         }
@@ -455,6 +450,50 @@ public class FundingProjectService {
     }
 
 
+    // 펀딩 프로젝트 조회
+    public ResponseEntity<ResponseBody> fundingProjectRead(Long projectId) {
+
+        // 조회하고자 하는 프로젝트
+        FundingProject readFundingProject = dynamicQueryDsl.getFundingProject(projectId);
+        // 프로젝트 메이커명
+        String makerName = readFundingProject.getMember().getMemberName();
+        // 조회하고자 하는 프로젝트에 속한 리워드 데이터들
+        List<Reward> readRewards = dynamicQueryDsl.getRewards(readFundingProject);
+        // 조회하고자 하는 프로젝트에 속한 미디어 데이터들
+        List<Media> readMedias = dynamicQueryDsl.getMedias(readFundingProject.getFundingProjectId());
+        // 프로젝트 찜한 수
+        Long countPick = dynamicQueryDsl.countPick(readFundingProject);
+        // 프로젝트 지지 수
+        Long countSupport = dynamicQueryDsl.countSupport(readFundingProject);
+        // 현재 조회하고있는 프로젝트와 유사한 프로젝트 네개 생성
+        List<FundingProject> getSimilarProjects = dynamicQueryDsl.getSimilarFundingProjects(readFundingProject);
+        // 현재 조회하고있는 프로젝트 메이커의 다른 프로젝트 4개 생성
+        List<FundingProject> getMakersOtherProjects = dynamicQueryDsl.getMakersOtherProjects(readFundingProject.getMember(), readFundingProject.getFundingProjectId());
+
+        // 프로젝트 종료까지 남은 일자 관련 변수
+        int projectEndDate = readFundingProject.getEndDate().getDayOfYear();
+        int todayDate = LocalDateTime.now().getDayOfYear();
+
+        ProjectReadResponseDto projectReadResponseDto = ProjectReadResponseDto.builder()
+                .fundingProject(readFundingProject)
+                .remainDate((projectEndDate - todayDate) + "일 남았습니다.")
+                .makerName(makerName)
+                .rewards(readRewards)
+                .medias(readMedias)
+                .countPick(countPick)
+                .countSupport(countSupport)
+                .similarProjects(getSimilarProjects)
+                .makersOtherProjects(getMakersOtherProjects)
+                .build();
+
+        // 리워드 옵션, 달성율 우선 스킵
+
+        HashMap<String, Object> resultSet = new HashMap<>();
+        resultSet.put("immediateResultMessage", "임의의 결과값 세트");
+        resultSet.put("resultInfo", projectReadResponseDto);
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, resultSet), HttpStatus.OK);
+    }
 }
 
 

--- a/src/main/java/com/example/zzapdiz/reward/domain/Reward.java
+++ b/src/main/java/com/example/zzapdiz/reward/domain/Reward.java
@@ -5,6 +5,7 @@ import com.example.zzapdiz.rewardoption.domain.RewardOption;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
@@ -13,6 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Getter
 @Entity
 public class Reward {
 
@@ -38,11 +40,11 @@ public class Reward {
     @Column(nullable = false)
     private String rewardContent; // 리워드 내용
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fundingProjectId")
     private FundingProject fundingProject;
 
-    @JsonIgnore
     @OneToMany(mappedBy = "reward", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RewardOption> rewardOptions;
 }

--- a/src/main/java/com/example/zzapdiz/reward/response/RewardInfoDto.java
+++ b/src/main/java/com/example/zzapdiz/reward/response/RewardInfoDto.java
@@ -1,0 +1,14 @@
+package com.example.zzapdiz.reward.response;
+
+import lombok.*;
+
+@Builder
+@Getter
+public class RewardInfoDto{
+    private int rewardQuantity;
+    private String rewardTitle;
+    private String rewardContent;
+    private String rewardOptionOnOff;
+    private String optionContent;
+    private int rewardAmount;
+}

--- a/src/main/java/com/example/zzapdiz/rewardoption/domain/RewardOption.java
+++ b/src/main/java/com/example/zzapdiz/rewardoption/domain/RewardOption.java
@@ -1,6 +1,7 @@
 package com.example.zzapdiz.rewardoption.domain;
 
 import com.example.zzapdiz.reward.domain.Reward;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,6 +23,7 @@ public class RewardOption {
     @Column(nullable = false)
     private String optionContent;
 
+    @JsonIgnore
     @JoinColumn(name = "rewardId")
     @ManyToOne(fetch = FetchType.LAZY)
     private Reward reward;

--- a/src/main/java/com/example/zzapdiz/share/query/DynamicQueryDsl.java
+++ b/src/main/java/com/example/zzapdiz/share/query/DynamicQueryDsl.java
@@ -1,10 +1,16 @@
 package com.example.zzapdiz.share.query;
 
+import com.example.zzapdiz.configuration.MySqlCustomTemplate;
 import com.example.zzapdiz.fundingproject.domain.FundingProject;
 import com.example.zzapdiz.member.domain.Member;
 import com.example.zzapdiz.member.request.MemberFindRequestDto;
+import com.example.zzapdiz.reward.domain.Reward;
+import com.example.zzapdiz.reward.response.RewardInfoDto;
 import com.example.zzapdiz.share.media.Media;
+import com.example.zzapdiz.share.project.ProjectCategory;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.MathExpressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityManager;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.example.zzapdiz.member.domain.QMember.member;
@@ -22,6 +29,7 @@ import static com.example.zzapdiz.share.media.QMedia.media;
 import static com.example.zzapdiz.fundingproject.domain.QFundingProject.fundingProject;
 import static com.example.zzapdiz.pickproject.domain.QPickProject.pickProject;
 import static com.example.zzapdiz.supportproject.domain.QDoSupport.doSupport;
+import static com.example.zzapdiz.reward.domain.QReward.reward;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -32,8 +40,10 @@ public class DynamicQueryDsl {
     private final EntityManager entityManager;
 
 
-    /** 조건에 따른 회원 정보 조회 동적 쿼리 **/
-    public Member findMemberByAnyCondition(MemberFindRequestDto memberFindRequestDto){
+    /**
+     * 조건에 따른 회원 정보 조회 동적 쿼리
+     **/
+    public Member findMemberByAnyCondition(MemberFindRequestDto memberFindRequestDto) {
         return jpaQueryFactory
                 .selectFrom(member)
                 .where(eqMemberId(memberFindRequestDto)
@@ -42,33 +52,41 @@ public class DynamicQueryDsl {
                 .fetchOne();
     }
 
-    /** 계정 ID에 따른 조회 조건 **/
+    /**
+     * 계정 ID에 따른 조회 조건
+     **/
     private BooleanExpression eqMemberId(MemberFindRequestDto memberFindRequestDto) {
-        if(memberFindRequestDto.getMemberId() > 0L){
+        if (memberFindRequestDto.getMemberId() > 0L) {
             return member.memberId.eq(memberFindRequestDto.getMemberId());
         }
         return null;
     }
 
-    /** 계정 이메일에 따른 조회 조건 **/
+    /**
+     * 계정 이메일에 따른 조회 조건
+     **/
     private BooleanExpression eqEmail(MemberFindRequestDto memberFindRequestDto) {
-        if(memberFindRequestDto.getEmail() != null){
+        if (memberFindRequestDto.getEmail() != null) {
             return member.email.eq(memberFindRequestDto.getEmail());
         }
         return null;
     }
 
-    /** 계정 회원 이름에 따른 조회 조건 **/
+    /**
+     * 계정 회원 이름에 따른 조회 조건
+     **/
     private BooleanExpression eqMemberName(MemberFindRequestDto memberFindRequestDto) {
-        if(memberFindRequestDto.getMemberName() != null){
+        if (memberFindRequestDto.getMemberName() != null) {
             return member.memberName.eq(memberFindRequestDto.getMemberName());
         }
         return null;
     }
 
 
-    /** 이메일로 회원 조회 **/
-    public Member findMemberByEmail(String email){
+    /**
+     * 이메일로 회원 조회
+     **/
+    public Member findMemberByEmail(String email) {
         Member loginMember = jpaQueryFactory
                 .selectFrom(member)
                 .where(member.email.eq(email))
@@ -77,9 +95,11 @@ public class DynamicQueryDsl {
         return loginMember;
     }
 
-    /** 토큰 삭제 처리 **/
+    /**
+     * 토큰 삭제 처리
+     **/
     @Transactional
-    public void deleteToken(Long memberId){
+    public void deleteToken(Long memberId) {
         jpaQueryFactory
                 .delete(token)
                 .where(token.memberId.eq(memberId))
@@ -89,9 +109,11 @@ public class DynamicQueryDsl {
         entityManager.clear();
     }
 
-    /** 회원탈퇴 시 회원 삭제 **/
+    /**
+     * 회원탈퇴 시 회원 삭제
+     **/
     @Transactional
-    public void deleteMember(Long memberId){
+    public void deleteMember(Long memberId) {
         jpaQueryFactory
                 .delete(member)
                 .where(member.memberId.eq(memberId))
@@ -101,9 +123,11 @@ public class DynamicQueryDsl {
         entityManager.clear();
     }
 
-    /** 미디어 삭제 **/
+    /**
+     * 미디어 삭제
+     **/
     @Transactional
-    public void deleteMedia(MultipartFile requestMedia){
+    public void deleteMedia(MultipartFile requestMedia) {
         jpaQueryFactory
                 .delete(media)
                 .where(media.mediaRealName.eq(requestMedia.getOriginalFilename()))
@@ -113,17 +137,21 @@ public class DynamicQueryDsl {
         entityManager.clear();
     }
 
-    /** 프로젝트에 속한 미디어들 조회 **/
-    public List<Media> findMedias(String projectTitle){
+    /**
+     * 프로젝트에 속한 미디어들 조회
+     **/
+    public List<Media> findMedias(String projectTitle) {
         return jpaQueryFactory
                 .selectFrom(media)
                 .where(media.projectTitle.eq(projectTitle))
                 .fetch();
     }
 
-    /** 미디어가 속한 프로젝트 id 업데이트 **/
+    /**
+     * 미디어가 속한 프로젝트 id 업데이트
+     **/
     @Transactional
-    public void updateMedia(Media updateMedia, Long fundingProjectId){
+    public void updateMedia(Media updateMedia, Long fundingProjectId) {
         jpaQueryFactory
                 .update(media)
                 .set(media.fundingProjectId, fundingProjectId)
@@ -134,8 +162,10 @@ public class DynamicQueryDsl {
         entityManager.clear();
     }
 
-    /** 펀딩 프로젝트 조회 **/
-    public FundingProject getFundingProject(Long projectId){
+    /**
+     * 펀딩 프로젝트 조회
+     **/
+    public FundingProject getFundingProject(Long projectId) {
         return jpaQueryFactory
                 .selectFrom(fundingProject)
                 .where(fundingProject.fundingProjectId.eq(projectId))
@@ -143,14 +173,16 @@ public class DynamicQueryDsl {
     }
 
 
-    /** 찜하기 두번 활성화 시 취소 **/
+    /**
+     * 찜하기 두번 활성화 시 취소
+     **/
     @Transactional
-    public Boolean pickCancel(Member authMember, FundingProject project){
+    public Boolean pickCancel(Member authMember, FundingProject project) {
 
-        if(jpaQueryFactory
+        if (jpaQueryFactory
                 .selectFrom(pickProject)
                 .where(pickProject.member.eq(authMember).and(pickProject.fundingProject.eq(project)))
-                .fetchOne() != null){
+                .fetchOne() != null) {
             jpaQueryFactory
                     .delete(pickProject)
                     .where(pickProject.member.eq(authMember).and(pickProject.fundingProject.eq(project)))
@@ -165,14 +197,16 @@ public class DynamicQueryDsl {
         return false;
     }
 
-    /** 지지하기 두번 활성화 시 취소 **/
+    /**
+     * 지지하기 두번 활성화 시 취소
+     **/
     @Transactional
-    public Boolean supportCancel(Member authMember, FundingProject project){
+    public Boolean supportCancel(Member authMember, FundingProject project) {
 
-        if(jpaQueryFactory
+        if (jpaQueryFactory
                 .selectFrom(doSupport)
                 .where(doSupport.member.eq(authMember).and(doSupport.fundingProject.eq(project)))
-                .fetchOne() != null){
+                .fetchOne() != null) {
             jpaQueryFactory
                     .delete(doSupport)
                     .where(doSupport.member.eq(authMember).and(doSupport.fundingProject.eq(project)))
@@ -187,4 +221,95 @@ public class DynamicQueryDsl {
         return false;
     }
 
+
+    /**
+     * 저장된 미디어 데이터들 조회
+     **/
+    public List<Media> getMedias(Long projectId) {
+        return jpaQueryFactory
+                .selectFrom(media)
+                .where(media.fundingProjectId.eq(projectId))
+                .fetch();
+    }
+
+
+    /**
+     * 프로젝트 찜한 수
+     **/
+    public Long countPick(FundingProject readProject) {
+        return jpaQueryFactory
+                .select(pickProject.count())
+                .from(pickProject)
+                .where(pickProject.fundingProject.eq(readProject))
+                .fetchOne();
+    }
+
+
+    /**
+     * 프로젝트 지지 수
+     **/
+    public Long countSupport(FundingProject readProject) {
+        return jpaQueryFactory
+                .select(doSupport.count())
+                .from(doSupport)
+                .where(doSupport.fundingProject.eq(readProject))
+                .fetchOne();
+    }
+
+
+    /**
+     * 프로젝트에 속한 리워드들 조회
+     **/
+    public List<Reward> getRewards(FundingProject readProject) {
+        List<Reward> rewardsList = jpaQueryFactory
+                .selectFrom(reward)
+                .where(reward.fundingProject.eq(readProject))
+                .fetch();
+
+//        List<RewardInfoDto> rewards = new ArrayList<>();
+//
+//        for(Reward eachReward : rewardsList){
+//            rewards.add(RewardInfoDto.builder()
+//                    .rewardQuantity(eachReward.))
+//        }
+
+        return rewardsList;
+    }
+
+    /**
+     * 현재 조회하고 있는 프로젝트와 동일한 카테고리를 가진 비슷한 프로젝트 4개 페이징 처리 목록
+     * !! 현재 랜덤으로 뽑혀야 되는 부분은 작동되지 않고 있다. 추후 반영 필요
+     **/
+    public List<FundingProject> getSimilarFundingProjects(FundingProject readFundingProject) {
+
+        MySqlCustomTemplate mySqlCustomTemplate = new MySqlCustomTemplate();
+        JPAQueryFactory jpaQueryFactory1 = new JPAQueryFactory(mySqlCustomTemplate, entityManager);
+
+        List<FundingProject> similarProjects = jpaQueryFactory1
+                .selectFrom(fundingProject)
+                .where(fundingProject.projectCategory.eq(readFundingProject.getProjectCategory())
+                        .and(fundingProject.fundingProjectId.ne(readFundingProject.getFundingProjectId())))
+                .limit(4)
+                .fetch();
+
+//        int randomPlace = (int)(Math.random() * Integer.parseInt(countSimilarProjects.toString()) + 1);
+
+        return similarProjects;
+    }
+
+
+    /**
+     * 현재 조회하고 있는 프로젝트의 메이커가 만든 다른 프로젝트 목록 4개 구성
+     * !! 현재 랜덤으로 뽑혀야 되는 부분은 작동되지 않고 있다. 추후 반영 필요
+     * **/
+    public List<FundingProject> getMakersOtherProjects(Member maker, Long projectId){
+        List<FundingProject> makersOtherProjects = jpaQueryFactory
+                .selectFrom(fundingProject)
+                .where(fundingProject.member.eq(maker)
+                        .and(fundingProject.fundingProjectId.ne(projectId)))
+                .limit(4)
+                .fetch();
+
+        return makersOtherProjects;
+    }
 }

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
@@ -1,16 +1,17 @@
 package com.example.zzapdiz.fundingproject;
 
 import com.example.zzapdiz.fundingproject.controller.FundingProjectController;
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
 import com.example.zzapdiz.fundingproject.request.*;
-import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase1ResponseDto;
-import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase2ResponseDto;
-import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase3ResponseDto;
-import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase4ResponseDto;
+import com.example.zzapdiz.fundingproject.response.*;
 import com.example.zzapdiz.fundingproject.service.FundingProjectService;
 import com.example.zzapdiz.reward.request.RewardCreateRequestDto;
 import com.example.zzapdiz.reward.response.RewardCreateResponseDto;
 import com.example.zzapdiz.share.ResponseBody;
 import com.example.zzapdiz.share.StatusCode;
+import com.example.zzapdiz.share.project.MakerType;
+import com.example.zzapdiz.share.project.ProjectCategory;
+import com.example.zzapdiz.share.project.ProjectType;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +31,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -245,6 +247,31 @@ public class FundingProjectConrollerTest {
 
     }
 
+    @DisplayName("[FundingProjectController] 펀딩 프로젝트 조회")
+    @Test
+    void readFundingProject() throws Exception {
+        // given
+        HashMap<String, Object> resultSet = new HashMap<>();
+        resultSet.put("resultMessage", "조회 테스트 성공");
+        resultSet.put("resultInfo", getReadResponse());
+
+        doReturn(new ResponseEntity<>(new ResponseBody<>(StatusCode.OK, resultSet), HttpStatus.OK))
+                .when(fundingProjectService)
+                .fundingProjectRead(1L);
+
+        // when
+        ResultActions resultActionsWhen = mockMvc.perform(
+                MockMvcRequestBuilders.get("/zzapdiz/funding/read/1")
+                        .characterEncoding("utf-8")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        ResultActions resultActionsThen = resultActionsWhen
+                .andDo(print())
+                .andExpect(status().isOk());
+
+    }
 
     private FundingProjectCreatePhase1RequestDto phase1RequestDto() {
         return FundingProjectCreatePhase1RequestDto.builder()
@@ -257,7 +284,7 @@ public class FundingProjectConrollerTest {
                 .build();
     }
 
-    private FundingProjectCreatePhase1ResponseDto phase1ResponseDto(){
+    private FundingProjectCreatePhase1ResponseDto phase1ResponseDto() {
         return FundingProjectCreatePhase1ResponseDto.builder()
                 .projectCategory("TECH")
                 .projectType("FIRST_OPEN")
@@ -277,7 +304,7 @@ public class FundingProjectConrollerTest {
                 .build();
     }
 
-    private FundingProjectCreatePhase2ResponseDto phase2ResponseDto(){
+    private FundingProjectCreatePhase2ResponseDto phase2ResponseDto() {
         return FundingProjectCreatePhase2ResponseDto.builder()
                 .projectTitle("생성 2단계 프로젝트 타이틀")
                 .endDate("20230314")
@@ -294,7 +321,7 @@ public class FundingProjectConrollerTest {
                 .build();
     }
 
-    private FundingProjectCreatePhase3ResponseDto phase3ResponseDto(){
+    private FundingProjectCreatePhase3ResponseDto phase3ResponseDto() {
         return FundingProjectCreatePhase3ResponseDto.builder()
                 .memberId(1L)
                 .storyText("프로젝트 소개글 완성")
@@ -310,7 +337,7 @@ public class FundingProjectConrollerTest {
                 .build();
     }
 
-    private FundingProjectCreatePhase4ResponseDto phase4ResponseDto(){
+    private FundingProjectCreatePhase4ResponseDto phase4ResponseDto() {
         return FundingProjectCreatePhase4ResponseDto.builder()
                 .memberId(1L)
                 .deliveryCheck("O")
@@ -330,7 +357,7 @@ public class FundingProjectConrollerTest {
                 .build();
     }
 
-    private RewardCreateResponseDto rewardCreateResponseDto(){
+    private RewardCreateResponseDto rewardCreateResponseDto() {
         return RewardCreateResponseDto.builder()
                 .memberId(1L)
                 .rewardTitle("리워드")
@@ -342,7 +369,7 @@ public class FundingProjectConrollerTest {
                 .build();
     }
 
-    private FundingRewardUpdateRequestDto fundingRewardUpdateRequestDto(){
+    private FundingRewardUpdateRequestDto fundingRewardUpdateRequestDto() {
         return FundingRewardUpdateRequestDto.builder()
                 .no(0)
                 .rewardContent("리워드 수정 테스트")
@@ -352,7 +379,7 @@ public class FundingProjectConrollerTest {
                 .build();
     }
 
-    private RewardCreateResponseDto updateReward(FundingRewardUpdateRequestDto fundingRewardUpdateRequestDto){
+    private RewardCreateResponseDto updateReward(FundingRewardUpdateRequestDto fundingRewardUpdateRequestDto) {
         return RewardCreateResponseDto.builder()
                 .memberId(2L)
                 .rewardQuantity(fundingRewardUpdateRequestDto.getRewardQuantity())
@@ -360,6 +387,32 @@ public class FundingProjectConrollerTest {
                 .rewardContent(fundingRewardUpdateRequestDto.getRewardContent())
                 .rewardAmount(fundingRewardUpdateRequestDto.getRewardAmount())
                 .no(fundingRewardUpdateRequestDto.getNo())
+                .build();
+    }
+
+    private ProjectReadResponseDto getReadResponse() {
+        FundingProject fakeProject = FundingProject.builder()
+                .fundingProjectId(1L)
+                .projectCategory("dd")
+                .projectType("dd")
+                .makerType("dd")
+                .achievedAmount(900)
+                .projectTitle("거짓 타이틀")
+                .endDate(LocalDateTime.now())
+                .adultCheck("X")
+                .searchTag("hh")
+                .storyText("kk")
+                .projectDescript("ll")
+                .openReservation("X")
+                .startDate(LocalDateTime.now())
+                .deliveryCheck("X")
+                .deliveryPrice(90000)
+                .deliveryStartDate(LocalDateTime.now())
+                .progress("진행중")
+                .build();
+
+        return ProjectReadResponseDto.builder()
+                .fundingProject(fakeProject)
                 .build();
     }
 

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectServiceTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectServiceTest.java
@@ -1,6 +1,8 @@
 package com.example.zzapdiz.fundingproject;
 
 import com.example.zzapdiz.exception.member.MemberException;
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.fundingproject.repository.FundingProjectRepository;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase1RequestDto;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase2RequestDto;
 import com.example.zzapdiz.fundingproject.request.FundingProjectCreatePhase4RequestDto;
@@ -9,9 +11,12 @@ import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase2Res
 import com.example.zzapdiz.fundingproject.response.FundingProjectCreatePhase4ResponseDto;
 import com.example.zzapdiz.fundingproject.service.FundingProjectService;
 import com.example.zzapdiz.jwt.JwtTokenProvider;
+import com.example.zzapdiz.member.domain.Member;
+import com.example.zzapdiz.member.repository.MemberRepository;
 import com.example.zzapdiz.member.request.MemberLoginRequestDto;
 import com.example.zzapdiz.reward.request.RewardCreateRequestDto;
 import com.example.zzapdiz.reward.response.RewardCreateResponseDto;
+import com.example.zzapdiz.share.query.DynamicQueryDsl;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +33,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,7 +47,13 @@ public class FundingProjectServiceTest {
     private FundingProjectService fundingProjectService;
 
     @Mock
-    private MemberException memberException;
+    private FundingProjectRepository fundingProjectRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private DynamicQueryDsl dynamicQueryDsl;
 
     @Mock
     private JwtTokenProvider jwtTokenProvider;
@@ -161,7 +173,56 @@ public class FundingProjectServiceTest {
     }
 
 
-    private FundingProjectCreatePhase1RequestDto phase1RequestDto(){
+    @DisplayName("[FundingProjectService] 펀딩 프로젝트 조회 서비스")
+    @Test
+    void readFundingProject() {
+        // given
+        Member authMember = Member.builder()
+                .memberId(1L)
+                .memberName("테스트 유저")
+                .email("test@naver.com")
+                .password("testpwd123!")
+                .point(0)
+                .build();
+
+        memberRepository.save(authMember);
+
+        FundingProject fakeProject = FundingProject.builder()
+                .fundingProjectId(1L)
+                .projectCategory("dd")
+                .projectType("dd")
+                .makerType("dd")
+                .achievedAmount(900)
+                .projectTitle("거짓 타이틀")
+                .endDate(LocalDateTime.now())
+                .adultCheck("X")
+                .searchTag("hh")
+                .storyText("kk")
+                .projectDescript("ll")
+                .openReservation("X")
+                .startDate(LocalDateTime.now())
+                .deliveryCheck("X")
+                .deliveryPrice(90000)
+                .deliveryStartDate(LocalDateTime.now())
+                .progress("진행중")
+                .member(authMember)
+                .build();
+
+        fundingProjectRepository.save(fakeProject);
+
+
+        // when
+        int statusCode = fundingProjectService.fundingProjectRead(1L).getStatusCodeValue();
+
+
+        // then
+        assertThat(statusCode).isEqualTo(200);
+
+
+    }
+
+
+    private FundingProjectCreatePhase1RequestDto phase1RequestDto() {
         return FundingProjectCreatePhase1RequestDto.builder()
                 .projectCategory("TECH")
                 .projectType("FIRST_OPEN")
@@ -172,7 +233,7 @@ public class FundingProjectServiceTest {
                 .build();
     }
 
-    private FundingProjectCreatePhase2RequestDto phase2RequestDto(){
+    private FundingProjectCreatePhase2RequestDto phase2RequestDto() {
         return FundingProjectCreatePhase2RequestDto.builder()
                 .projectTitle("생성 2단계 프로젝트 타이틀")
                 .endDate("20230314")
@@ -181,7 +242,7 @@ public class FundingProjectServiceTest {
                 .build();
     }
 
-    private FundingProjectCreatePhase2ResponseDto phase2ResponseDto(){
+    private FundingProjectCreatePhase2ResponseDto phase2ResponseDto() {
         return FundingProjectCreatePhase2ResponseDto.builder()
                 .projectTitle("생성 2단계 프로젝트 타이틀")
                 .endDate("20230314")
@@ -197,7 +258,7 @@ public class FundingProjectServiceTest {
                 .build();
     }
 
-    private FundingProjectCreatePhase4ResponseDto phase4ResponseDto(){
+    private FundingProjectCreatePhase4ResponseDto phase4ResponseDto() {
         return FundingProjectCreatePhase4ResponseDto.builder()
                 .memberId(1L)
                 .deliveryCheck("O")
@@ -217,7 +278,7 @@ public class FundingProjectServiceTest {
                 .build();
     }
 
-    private RewardCreateResponseDto rewardCreateResponseDto(){
+    private RewardCreateResponseDto rewardCreateResponseDto() {
         return RewardCreateResponseDto.builder()
                 .memberId(1L)
                 .rewardTitle("리워드")
@@ -230,8 +291,8 @@ public class FundingProjectServiceTest {
     }
 
 
-    private List<RewardCreateRequestDto> rewardCreateRequestDtos(){
-        List<RewardCreateRequestDto> rewardRequests= new ArrayList<>();
+    private List<RewardCreateRequestDto> rewardCreateRequestDtos() {
+        List<RewardCreateRequestDto> rewardRequests = new ArrayList<>();
 
         rewardRequests.add(
                 RewardCreateRequestDto.builder()
@@ -266,14 +327,14 @@ public class FundingProjectServiceTest {
         return rewardRequests;
     }
 
-    private MemberLoginRequestDto memberLoginRequestDto(){
+    private MemberLoginRequestDto memberLoginRequestDto() {
         return MemberLoginRequestDto.builder()
                 .email("wlstpgns51@naver.com")
                 .password("wls124578!")
                 .build();
     }
 
-    private FundingRewardUpdateRequestDto fundingRewardUpdateRequestDto(){
+    private FundingRewardUpdateRequestDto fundingRewardUpdateRequestDto() {
         return FundingRewardUpdateRequestDto.builder()
                 .no(0)
                 .rewardContent("리워드 수정 테스트")

--- a/src/test/java/com/example/zzapdiz/other/OtherTest.java
+++ b/src/test/java/com/example/zzapdiz/other/OtherTest.java
@@ -1,0 +1,49 @@
+package com.example.zzapdiz.other;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+
+import static com.example.zzapdiz.fundingproject.domain.QFundingProject.fundingProject;
+
+@SpringBootTest
+public class OtherTest {
+
+    @Autowired
+    private JPAQueryFactory jpaQueryFactory;
+
+    // 날짜 빼기 테스트
+    @DisplayName("날짜 빼기 테스트")
+    @Test
+    void dateCalculateTest() {
+        FundingProject testProject = jpaQueryFactory
+                .selectFrom(fundingProject)
+                .where(fundingProject.fundingProjectId.eq(1L))
+                .fetchOne();
+
+
+        int projectYear = testProject.getEndDate().getYear();
+        int projectMonth = testProject.getEndDate().getMonthValue();
+        int projectDay = testProject.getEndDate().getDayOfYear();
+
+        int nowYear = LocalDateTime.now().getYear();
+        int nowMonth = LocalDateTime.now().getDayOfMonth();
+        int nowDay = LocalDateTime.now().getDayOfYear();
+
+        System.out.println("프로젝트 end_date에 기입된 날짜 정보");
+        System.out.println("년도 - " + projectYear + " 월 - " + projectMonth + " 일 - " + projectDay);
+
+        System.out.println("현재 날짜 기준 날짜 정보");
+        System.out.println("넌도 - " + nowYear + " 월 - " + nowMonth + " 일 - " + nowDay);
+
+        System.out.println("테스트 결과 보여주세요!!!!!!!!!!!!!!!!!!!!!");
+//        System.out.println(LocalDateTime.now().get);
+    }
+}

--- a/src/test/java/com/example/zzapdiz/query/QueryTestConfig.java
+++ b/src/test/java/com/example/zzapdiz/query/QueryTestConfig.java
@@ -1,0 +1,20 @@
+package com.example.zzapdiz.query;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@TestConfiguration
+public class QueryTestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
[Feature/Funding/Read]
- FundingProjectController 펀딩 프로젝트 조회 api 1차 구현
- FundingProjectService 펀딩 프로젝트 조회 api 비즈니스 로직 1차 구현
- 펀딩 프로젝트 조회 시 반환 될 객체 ProjectReadResponseDto 생성
- FundingProject 엔티티 연관관계 맺은 Member 엔티티 @JsonIgnore 설정
- Reward 엔티티 순환 참조 방지를 위한 연관관계 맺은 FundingProject 엔티티 @JsonIgnore 설정
- Reward 엔티티 조회 시 하위 엔티티인 RewardOption 엔티티 순환 참조 방지를 위한 RewardOption 엔티티에서 Reward 엔티티 @JsonIgnore 설정
- 펀딩 프로젝트 조회 api 컨트롤러 테스트 코드 작성
- 펀딩 프로젝트 조회 api 비즈니스 로직 테스트 코드 보류

!! 펀딩 프로젝트 조회할 때 비슷한 프로젝트 4개 목록 랜덤 생성 및 메이커의 다른 프로젝트 4개 목록 랜덤 생성 로직은 아직 미반영
   추후 추가 예정 필요