### PR TITLE
펀딩 프로젝트 목록 조회 api 1차 구현

### DIFF
--- a/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
@@ -1,6 +1,7 @@
 package com.example.zzapdiz.fundingproject.controller;
 
 import com.example.zzapdiz.fundingproject.request.*;
+import com.example.zzapdiz.fundingproject.response.ProjectsReadResponseDto;
 import com.example.zzapdiz.fundingproject.service.FundingProjectService;
 import com.example.zzapdiz.reward.request.RewardCreateRequestDto;
 import com.example.zzapdiz.share.ResponseBody;
@@ -95,5 +96,17 @@ public class FundingProjectController {
         log.info("펀딩 프로젝트 조회 api : 프로젝트 - {}", projectId);
 
         return fundingProjectService.fundingProjectRead(projectId);
+    }
+
+    /**
+     * 펀딩 프로젝트 목록 조회
+     * (1) 프로젝트 카테고리 / (2) 진행상황 / (3) 정렬기준 / (4) 12개씩 페이지 번호
+     * **/
+    @GetMapping("/funding/readlist")
+    public ResponseEntity<ResponseBody> fundingProjectsRead(@RequestBody ProjectsListReadRequestDto projectsListReadRequestDto){
+        log.info("펀딩 프로젝트 목록 조회 api : 카테고리 - {}, 진행상황 - {}, 정렬기준 - {}, 목록 번호 - {}",
+                projectsListReadRequestDto.getProjectCategory(), projectsListReadRequestDto.getProgress(), projectsListReadRequestDto.getOrderBy(), projectsListReadRequestDto.getPageNum());
+
+        return fundingProjectService.fundingProjectsRead(projectsListReadRequestDto);
     }
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/domain/FundingProject.java
@@ -75,6 +75,15 @@ public class FundingProject extends Timestamped {
     @Column
     private LocalDateTime deliveryStartDate;
 
+    @Column
+    private int supportCount;
+
+    @Column
+    private int pickCount;
+
+    @Column
+    private int collectQuantity;
+
     @JsonIgnore
     @JoinColumn(name = "memberId")
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/zzapdiz/fundingproject/request/ProjectsListReadRequestDto.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/request/ProjectsListReadRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.zzapdiz.fundingproject.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ProjectsListReadRequestDto {
+    private String projectCategory;
+    private String progress;
+    private String orderBy;
+    private Integer pageNum;
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/response/ProjectsReadResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/response/ProjectsReadResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.zzapdiz.fundingproject.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ProjectsReadResponseDto {
+    private Long fundingProjectId;
+    private String projectTitle;
+    private String reachPercentage;
+    private String reachQuantity;
+    private String remainProjectDate;
+    private String thumbnailImage;
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
@@ -345,6 +345,8 @@ public class FundingProjectService {
                 .deliveryPrice(phase4.get().getDeliveryPrice())
                 .deliveryStartDate(deliveryStartDate)
                 .progress("진행중")
+                .supportCount(0)
+                .collectQuantity(0)
                 .member(authMember)
                 .build();
 
@@ -489,8 +491,23 @@ public class FundingProjectService {
         // 리워드 옵션, 달성율 우선 스킵
 
         HashMap<String, Object> resultSet = new HashMap<>();
-        resultSet.put("immediateResultMessage", "임의의 결과값 세트");
+        resultSet.put("resultMessage", "펀딩 프로젝트 조회");
         resultSet.put("resultInfo", projectReadResponseDto);
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, resultSet), HttpStatus.OK);
+    }
+
+
+    // 펀딩 프로젝트 목록 조회
+    public ResponseEntity<ResponseBody> fundingProjectsRead(ProjectsListReadRequestDto projectsListReadRequestDto){
+
+        // 펀딩 프로젝트 목록 12개씩 리스트 추출
+        List<ProjectsReadResponseDto> projectLists = dynamicQueryDsl.getProjectList(
+                projectsListReadRequestDto.getProjectCategory(), projectsListReadRequestDto.getProgress(), projectsListReadRequestDto.getOrderBy(), projectsListReadRequestDto.getPageNum());
+
+        HashMap<String, Object> resultSet = new HashMap<>();
+        resultSet.put("resultMessage", "펀딩 프로젝트 목록 조회");
+        resultSet.put("resultInfo", projectLists);
 
         return new ResponseEntity<>(new ResponseBody(StatusCode.OK, resultSet), HttpStatus.OK);
     }

--- a/src/main/java/com/example/zzapdiz/pickproject/service/PickProjectService.java
+++ b/src/main/java/com/example/zzapdiz/pickproject/service/PickProjectService.java
@@ -63,6 +63,9 @@ public class PickProjectService {
 
         pickProjectRepository.save(pickProject);
 
+        // 찜하기 수 업데이트
+        dynamicQueryDsl.pickCountUpdate(pickFundingProject);
+
         // 출력 결과 확인 HashMap
         HashMap<String, Object> resultSet = new HashMap<>();
         resultSet.put("pickMessage", "찜!");

--- a/src/main/java/com/example/zzapdiz/supportproject/service/DoSupportService.java
+++ b/src/main/java/com/example/zzapdiz/supportproject/service/DoSupportService.java
@@ -59,6 +59,9 @@ public class DoSupportService {
 
         doSupportRepository.save(doSupport);
 
+        // 지지수 업데이트
+        dynamicQueryDsl.supportCountUpdate(supportProject);
+
         HashMap<String, Object> resultSet = new HashMap<>();
         resultSet.put("supportMessage", "지지!");
         resultSet.put("supportInfo", doSupportResponseDto(doSupport));

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
@@ -273,6 +273,35 @@ public class FundingProjectConrollerTest {
 
     }
 
+    @DisplayName("[FundingProjectController] 펀딩 프로젝트 목록 조회")
+    @Test
+    void readFundingProjectList() throws Exception{
+        // given
+        HashMap<String, Object> resultSet = new HashMap<>();
+        resultSet.put("resultMessage", "펀딩 프로젝트 목록 조회");
+        resultSet.put("resultInfo", projectsReadResult());
+
+        doReturn(new ResponseEntity<>(new ResponseBody<>(StatusCode.OK, resultSet), HttpStatus.OK))
+                .when(fundingProjectService)
+                .fundingProjectsRead(any(ProjectsListReadRequestDto.class));
+
+        String projectsReadRequest = new Gson().toJson(projectsRead());
+
+        // when
+        ResultActions resultActionsWhen = mockMvc.perform(
+                MockMvcRequestBuilders.get("/zzapdiz/funding/readlist")
+                        .characterEncoding("utf-8")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(projectsReadRequest)
+        );
+
+        // then
+        ResultActions resultActionsThen = resultActionsWhen
+                .andDo(print())
+                .andExpect(status().isOk());
+
+    }
+
     private FundingProjectCreatePhase1RequestDto phase1RequestDto() {
         return FundingProjectCreatePhase1RequestDto.builder()
                 .projectCategory("TECH")
@@ -413,6 +442,24 @@ public class FundingProjectConrollerTest {
 
         return ProjectReadResponseDto.builder()
                 .fundingProject(fakeProject)
+                .build();
+    }
+
+    private ProjectsListReadRequestDto projectsReadResult(){
+        return ProjectsListReadRequestDto.builder()
+                .projectCategory("테크/가전")
+                .progress("진행중")
+                .orderBy("")
+                .pageNum(1)
+                .build();
+    }
+
+    private ProjectsListReadRequestDto projectsRead(){
+        return ProjectsListReadRequestDto.builder()
+                .projectCategory("테크/가전")
+                .progress("진행중")
+                .orderBy("")
+                .pageNum(1)
                 .build();
     }
 

--- a/src/test/java/com/example/zzapdiz/query/QueryTest.java
+++ b/src/test/java/com/example/zzapdiz/query/QueryTest.java
@@ -1,0 +1,89 @@
+package com.example.zzapdiz.query;
+
+import com.example.zzapdiz.configuration.MySqlCustomTemplate;
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.fundingproject.repository.FundingProjectRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.zzapdiz.fundingproject.domain.QFundingProject.fundingProject;
+
+@DataJpaTest
+@Import(QueryTestConfig.class)
+//@ExtendWith(MockitoExtension.class)
+public class QueryTest {
+
+//    @Mock
+//    private EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    private JPAQueryFactory jpaQueryFactory;
+
+    @Autowired
+    private FundingProjectRepository fundingProjectRepository;
+
+    /**
+     * 현재 조회하고 있는 프로젝트와 동일한 카테고리를 가진 비슷한 프로젝트 4개 페이징 처리 목록
+     **/
+    @DisplayName("커스텀 JPQLTemplate + 랜덤 레코드 추출 테스트")
+    @Test
+    void getSimilarFundingProjects() {
+
+        fundingProjectRepository.save(getFakeProject(1L));
+        fundingProjectRepository.save(getFakeProject(2L));
+        fundingProjectRepository.save(getFakeProject(3L));
+        fundingProjectRepository.save(getFakeProject(4L));
+        fundingProjectRepository.save(getFakeProject(5L));
+        fundingProjectRepository.save(getFakeProject(6L));
+        fundingProjectRepository.save(getFakeProject(7L));
+
+//        EntityManager entityManager = entityManagerFactory.createEntityManager();
+//        MySqlCustomTemplate mySqlCustomTemplate = new MySqlCustomTemplate();
+//        JPAQueryFactory jpaQueryFactory = new JPAQueryFactory();
+
+        List<FundingProject> similarProjects = jpaQueryFactory
+                .selectFrom(fundingProject)
+                .where(fundingProject.projectCategory.eq("전자/가전")
+                        .and(fundingProject.fundingProjectId.ne(1L)))
+//                .orderBy(NumberExpression.random().asc())
+                .limit(4)
+                .fetch();
+
+        for (FundingProject project : similarProjects) {
+            System.out.println("프로젝트 랜덤 추출 확인 " + project.getFundingProjectId());
+        }
+    }
+
+
+    private FundingProject getFakeProject(Long id) {
+        return FundingProject.builder()
+                .fundingProjectId(id)
+                .projectTitle("테스트용 프로젝트명")
+                .projectCategory("전자/가전")
+                .projectType("손수 제작")
+                .achievedAmount(90000000)
+                .adultCheck("X")
+                .searchTag("#검색태그")
+                .storyText("프로젝트 스토리~~")
+                .projectDescript("프로젝트 요약 설명~~")
+                .openReservation("X")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now())
+                .makerType("PERSONAL")
+                .progress("진행중")
+                .deliveryCheck("X")
+                .build();
+    }
+}


### PR DESCRIPTION
[Feature/Funding/ReadList]
- FundingProjectController 펀딩 프로젝트 목록 조회 api 1차 구현
- FundingProjectService 펀딩 프로젝트 목록 조회 api 비즈니스 로직 1차 구현
- 펀딩 프로젝트 목록 조회를 위한 RequestDto 객체 생성
- 펀딩 프로젝트 목록들의 정보를 담기 위한 ResponseDto 객체 생성
- FundingProject 엔티티 supportCount(지지하기 수), pickCount(찜하기 수), collectQuantity(달성 금액) 속성 추가
- DoSupportService에 supportCount 업데이트 로직 추가
- PickProjectService에 pickCoun 업데이트 로직 추가
- DynamicQueryDsl 에 지지하기, 찜하기 쿼리 함수 작성 및 프로젝트 목록 조회 부분 동적쿼리 함수 작성
- 테스트 코드 작성 보류