### PR TITLE
펀딩 프로젝트 종료 api 1차 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ dependencies {
     // Aws dependency
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    // batch + quartz
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-batch', version: '3.0.5'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-quartz', version: '3.0.5'
+    testImplementation group: 'org.springframework.batch', name: 'spring-batch-test', version: '4.3.8'
 
 }
 

--- a/src/main/java/com/example/zzapdiz/ZzapdizApplication.java
+++ b/src/main/java/com/example/zzapdiz/ZzapdizApplication.java
@@ -1,10 +1,13 @@
 package com.example.zzapdiz;
 
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableBatchProcessing
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class ZzapdizApplication {

--- a/src/main/java/com/example/zzapdiz/configuration/BatchConfig.java
+++ b/src/main/java/com/example/zzapdiz/configuration/BatchConfig.java
@@ -1,0 +1,78 @@
+package com.example.zzapdiz.configuration;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.share.query.DynamicQueryDsl;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static com.example.zzapdiz.fundingproject.domain.QFundingProject.fundingProject;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+//@EnableBatchProcessing
+public class BatchConfig {
+
+//    private static String nowDate = LocalDateTime.now().toString();
+
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final JPAQueryFactory jpaQueryFactory;
+    private final DynamicQueryDsl dynamicQueryDsl;
+
+
+    // 스케줄러와 배치를 통한 작업
+    @Bean
+    public Job job() {
+
+        return jobBuilderFactory.get("job")
+                .start(step())
+                .build();
+    }
+
+
+    // job을 수행하기 위한 step 과정
+    @Bean
+    public Step step() {
+        // 프로젝트 종료일과 비교할 현재 날짜
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"); // 날짜와 시간 포맷 형식
+        String nowDate = LocalDateTime.now().toString().replace('T', ' '); // 날짜 시간 문자열 중간에 있는 T 문자 삭제
+        String[] dateSplit = nowDate.split("\\."); // 포맷 형식에 맞게끔 . 기호를 기준으로 필요한 문자열만 추출
+        LocalDateTime nowDateTime = LocalDateTime.parse(dateSplit[0], formatter); // 추출한 날짜 데이터에 포맷 형식 적용
+
+        // 스케줄러를 통해 수행될 step 작업
+        return stepBuilderFactory.get("step")
+                .tasklet((contribution, chunkContext) -> {
+                    log.info("step!");
+
+                    // 현재 진행 중인 상태이고 현재 날짜가 프로젝트 종료일을 넘긴 프로젝트들 조회
+                    List<FundingProject> fundingProjects = jpaQueryFactory
+                            .selectFrom(fundingProject)
+                            .where(fundingProject.progress.eq("진행중").and(fundingProject.endDate.loe(nowDateTime)))
+                            .fetch();
+
+                    // 자동 종료시킬 프로젝트가 존재할 경우 작업 수행
+                    if (!fundingProjects.isEmpty()) {
+                        // 각 프로젝트들의 진행상황을 종료로 변환
+                        for (FundingProject eachProject : fundingProjects) {
+                            dynamicQueryDsl.updateProjectProgress(eachProject.getFundingProjectId());
+                        }
+                    }
+
+                    return RepeatStatus.FINISHED;
+                }).build();
+    }
+
+}

--- a/src/main/java/com/example/zzapdiz/configuration/BatchScheduler.java
+++ b/src/main/java/com/example/zzapdiz/configuration/BatchScheduler.java
@@ -1,0 +1,39 @@
+package com.example.zzapdiz.configuration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.engine.jdbc.batch.spi.Batch;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class BatchScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final BatchConfig batchConfig;
+
+    @Scheduled(cron = "0 0 9 * * *")
+    public void runJob(){
+        Map<String, JobParameter> confMap = new HashMap<>();
+        confMap.put("time", new JobParameter(System.currentTimeMillis()));
+        JobParameters jobParameters = new JobParameters(confMap);
+
+        try{
+            jobLauncher.run(batchConfig.job(), jobParameters);
+        }catch(JobExecutionAlreadyRunningException | JobInstanceAlreadyCompleteException | JobParametersInvalidException | JobRestartException e){
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/controller/FundingProjectController.java
@@ -151,4 +151,15 @@ public class FundingProjectController {
 
         return fundingProjectService.fundingProjectUpdate(request, fundingProjectUpdateRequestDto, thumbnailImage, videoAndImages);
     }
+
+
+    /**
+     * 펀딩 프로젝트 종료
+     */
+    @PatchMapping("/funding/end/{projectId}")
+    public ResponseEntity<ResponseBody> fundingProjectEnd(HttpServletRequest request, @PathVariable Long projectId){
+        log.info("펀딩 프로젝트 종료 api : 종료 요청 유저 - {}, 종료 프로젝트 id - {}", request, projectId);
+
+        return fundingProjectService.fundingProjectEnd(request, projectId);
+    }
 }

--- a/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
+++ b/src/main/java/com/example/zzapdiz/fundingproject/service/FundingProjectService.java
@@ -574,6 +574,27 @@ public class FundingProjectService {
 
         return new ResponseEntity<>(new ResponseBody(StatusCode.OK, "프로젝트 정보가 정상적으로 수정되었습니다."), HttpStatus.OK);
     }
+
+    // 펀딩 프로젝트 수동 종료
+    public ResponseEntity<ResponseBody> fundingProjectEnd(HttpServletRequest request, Long projectId){
+
+        // 펀딩 프로젝트 삭제 요청 회원의 토큰 유효성 검증
+        if (memberExceptionInterface.checkHeaderToken(request)) {
+            return new ResponseEntity<>(new ResponseBody(StatusCode.UNAUTHORIZED_TOKEN, null), HttpStatus.BAD_REQUEST);
+        }
+
+        Member authMember = jwtTokenProvider.getMemberFromAuthentication();
+
+        // 종료하려고 하는 유저가 만든 프로젝트가 맞는지 확인
+        if(!fundingProejctExceptionInterface.checkProjectMaker(authMember, projectId)){
+            return new ResponseEntity<>(new ResponseBody(StatusCode.NOT_CORRECT_MAKER, null), HttpStatus.BAD_REQUEST);
+        }
+
+        // 프로젝트 종료
+        dynamicQueryDsl.updateProjectProgress(projectId);
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, "프로젝트가 종료되었습니다."), HttpStatus.OK);
+    }
 }
 
 

--- a/src/main/java/com/example/zzapdiz/share/query/DynamicQueryDsl.java
+++ b/src/main/java/com/example/zzapdiz/share/query/DynamicQueryDsl.java
@@ -635,4 +635,21 @@ public class DynamicQueryDsl {
 
     }
 
+    /**
+     * 프로젝트 진행 상황 변경
+     */
+    @Transactional
+    public void updateProjectProgress(Long projectId){
+
+        jpaQueryFactory
+                .update(fundingProject)
+                .set(fundingProject.progress, "종료")
+                .where(fundingProject.fundingProjectId.eq(projectId))
+                .execute();
+
+        entityManager.flush();
+        entityManager.clear();
+
+    }
+
 }

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectConrollerTest.java
@@ -362,6 +362,31 @@ public class FundingProjectConrollerTest {
 
     }
 
+    @DisplayName("[FundingProjectController] 펀딩 프로젝트 종료")
+    @Test
+    void endProject() throws Exception {
+        // given
+        doReturn(new ResponseEntity<>(new ResponseBody(StatusCode.OK, "정상적으로 프로젝트가 종료되었습니다."), HttpStatus.OK))
+                .when(fundingProjectService)
+                .fundingProjectEnd(any(MockHttpServletRequest.class), any(Long.class));
+
+        fundingProjectRepository.save(getFakeProject());
+
+        // when
+        ResultActions resultActionsWhen = mockMvc.perform(
+                MockMvcRequestBuilders.patch("/zzapdiz/funding/end/3")
+                        .characterEncoding("utf-8")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ3bHN0cGduczUyQG5hdmVyLmNvbSIsImF1dGgiOiJVU0VSIiwiZXhwIjoxNjgzNzk1OTAyfQ.tQBurIWDawjuxvoTbYjzzG3sPzhDRLlzLPoNskFoQDg")
+        );
+
+        // then
+        ResultActions resultActionsThen = resultActionsWhen
+                .andDo(print())
+                .andExpect(status().isOk());
+
+    }
+
 
     private FundingProjectCreatePhase1RequestDto phase1RequestDto() {
         return FundingProjectCreatePhase1RequestDto.builder()

--- a/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectServiceTest.java
+++ b/src/test/java/com/example/zzapdiz/fundingproject/FundingProjectServiceTest.java
@@ -210,14 +210,25 @@ public class FundingProjectServiceTest {
 
         fundingProjectRepository.save(fakeProject);
 
-
         // when
         int statusCode = fundingProjectService.fundingProjectRead(1L).getStatusCodeValue();
-
 
         // then
         assertThat(statusCode).isEqualTo(200);
 
+    }
+
+    @DisplayName("[FundingProjectService] 펀딩 프로젝트 종료 서비스")
+    @Test
+    void endProject() {
+        // given
+        fundingProjectRepository.save(getFakeProject());
+
+        // when
+        int statusCode = fundingProjectService.fundingProjectEnd(any(MockHttpServletRequest.class),3L).getStatusCodeValue();
+
+        // then
+        assertThat(statusCode).isEqualTo(200);
 
     }
 
@@ -342,5 +353,29 @@ public class FundingProjectServiceTest {
                 .rewardQuantity(80000)
                 .rewardAmount(90)
                 .build();
+    }
+
+    private FundingProject getFakeProject(){
+        FundingProject fakeProject = FundingProject.builder()
+                .fundingProjectId(3L)
+                .projectCategory("dd")
+                .projectType("dd")
+                .makerType("dd")
+                .achievedAmount(900)
+                .projectTitle("거짓 타이틀")
+                .endDate(LocalDateTime.now())
+                .adultCheck("X")
+                .searchTag("hh")
+                .storyText("kk")
+                .projectDescript("ll")
+                .openReservation("X")
+                .startDate(LocalDateTime.now())
+                .deliveryCheck("X")
+                .deliveryPrice(90000)
+                .deliveryStartDate(LocalDateTime.now())
+                .progress("진행중")
+                .build();
+
+        return fakeProject;
     }
 }


### PR DESCRIPTION
[Feature/Funding/End]
- FundingProjectController 펀딩 프로젝트 종료 api 1차 구현
- FundingProejctService 펀딩 프로젝트 종료 비즈니스 로직 1차 구현
- DynamicQueryDsl 에 progress 속성을 업데이트 하는 함수 로직 생성
- build.gradle에 batch, quartz 의존성 추가
- application.properties에 batch 스키마 자동 생성 설정과 어플리케이션 시작과 동시에 batch가 실행되는 것을 방지하는 설정 추가
- Application 실행 객체 파일에 batch와 scheduling 을 사용하기 위한 @EnableBatchProcessing, @EnableScheduling 어노테이션 추가
- Batch와 Scheduling을 사용하기 위한 BatchConfig, BatchScheduling 설정 객체 파일 생성
- Service 테스트 코드 작성 보류