### PR TITLE
메인 페이지 호출 출력 api 1차 구현

### DIFF
--- a/src/main/java/com/example/zzapdiz/configuration/BatchConfig.java
+++ b/src/main/java/com/example/zzapdiz/configuration/BatchConfig.java
@@ -1,6 +1,7 @@
 package com.example.zzapdiz.configuration;
 
 import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.page.service.PageService;
 import com.example.zzapdiz.share.query.DynamicQueryDsl;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -31,16 +32,26 @@ public class BatchConfig {
     private final StepBuilderFactory stepBuilderFactory;
     private final JPAQueryFactory jpaQueryFactory;
     private final DynamicQueryDsl dynamicQueryDsl;
+    private final PageService pageService;
 
 
-    // 스케줄러와 배치를 통한 작업
+    // 스케줄러와 배치를 통한 작업 (프로젝트 자동 종료)
     @Bean
-    public Job job() {
+    public Job progressUpdateJob() {
 
         return jobBuilderFactory.get("job")
                 .start(step())
                 .build();
     }
+
+    // 스케줄러와 배치를 통한 작업 (랭킹 프로젝트 업데이트 리스트업)
+//    @Bean
+//    public Job rankingProjectsUpdateJob() {
+//
+//        return jobBuilderFactory.get("job")
+//                .start(step2())
+//                .build();
+//    }
 
 
     // job을 수행하기 위한 step 과정
@@ -74,5 +85,24 @@ public class BatchConfig {
                     return RepeatStatus.FINISHED;
                 }).build();
     }
+
+//    @Bean
+//    public Step step2(){
+//        return stepBuilderFactory.get("step")
+//                .tasklet((contribution, chunkContext) -> {
+//                    log.info("step!");
+//
+//                    /**
+//                     * 펀딩 달성율 구하는 로직을 만들고 해당 달성율이 가장 높은 프로젝트를 스케줄러를 활용하여
+//                     * 매 시간 (1시간 간격) 마다 업데이트하는 step 만들어야 함.
+//                     *
+//                     */
+//
+//                    // 굳이 스케줄러랑 배치로 해야할까?
+//                    // pageService.readMainPage();
+//
+//                    return RepeatStatus.FINISHED;
+//                }).build();
+//    }
 
 }

--- a/src/main/java/com/example/zzapdiz/configuration/BatchScheduler.java
+++ b/src/main/java/com/example/zzapdiz/configuration/BatchScheduler.java
@@ -24,6 +24,7 @@ public class BatchScheduler {
     private final JobLauncher jobLauncher;
     private final BatchConfig batchConfig;
 
+    // 매일 오전 9시에 프로젝트 종료일에 도달하거나 초과한 프로젝트 자동 종료 수행 스케줄
     @Scheduled(cron = "0 0 9 * * *")
     public void runJob(){
         Map<String, JobParameter> confMap = new HashMap<>();
@@ -31,9 +32,23 @@ public class BatchScheduler {
         JobParameters jobParameters = new JobParameters(confMap);
 
         try{
-            jobLauncher.run(batchConfig.job(), jobParameters);
+            jobLauncher.run(batchConfig.progressUpdateJob(), jobParameters);
         }catch(JobExecutionAlreadyRunningException | JobInstanceAlreadyCompleteException | JobParametersInvalidException | JobRestartException e){
             log.error(e.getMessage());
         }
     }
+
+    // 매 1시간마다 달성율에 따른 프로젝트 랭킹 리스트업 스케줄
+//    @Scheduled(cron = "0 0 * * * *")
+//    public void runJob2(){
+//        Map<String, JobParameter> confMap = new HashMap<>();
+//        confMap.put("time", new JobParameter(System.currentTimeMillis()));
+//        JobParameters jobParameters = new JobParameters(confMap);
+//
+//        try{
+//            jobLauncher.run(batchConfig.rankingProjectsUpdateJob(), jobParameters);
+//        }catch(JobExecutionAlreadyRunningException | JobInstanceAlreadyCompleteException | JobParametersInvalidException | JobRestartException e){
+//            log.error(e.getMessage());
+//        }
+//    }
 }

--- a/src/main/java/com/example/zzapdiz/configuration/SecurityConfig.java
+++ b/src/main/java/com/example/zzapdiz/configuration/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
                         "/zzapdiz/member/login",
                         "/zzapdiz/member/findid",
                         "/zzapdiz/funding/read/**",
-                        "/zzapdiz/funding/readlist/**").permitAll()
+                        "/zzapdiz/funding/readlist/**",
+                        "/zzapdiz/page/**").permitAll()
                 .antMatchers("/test").hasRole("USER")
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/com/example/zzapdiz/dofundproject/request/InputQuantityDto.java
+++ b/src/main/java/com/example/zzapdiz/dofundproject/request/InputQuantityDto.java
@@ -1,8 +1,12 @@
 package com.example.zzapdiz.dofundproject.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 @Getter
 public class InputQuantityDto {

--- a/src/main/java/com/example/zzapdiz/dofundproject/response/FundingRewardResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/dofundproject/response/FundingRewardResponseDto.java
@@ -9,14 +9,10 @@ import java.io.Serializable;
 
 @NoArgsConstructor
 @AllArgsConstructor
-@Component
-@RedisHash(value = "doFundPhase1ResponseDto", timeToLive = 1800)
 @Builder
-@Setter
 @Getter
-public class DoFundPhase1ResponseDto implements Serializable {
-
-    @Id
+public class FundingRewardResponseDto{
     private Long memberId;
     private Long fundingProjectId;
+    private Long rewardId;
 }

--- a/src/main/java/com/example/zzapdiz/exception/dofundproject/DoFundProjectException.java
+++ b/src/main/java/com/example/zzapdiz/exception/dofundproject/DoFundProjectException.java
@@ -65,21 +65,24 @@ public class DoFundProjectException implements DoFundProjectExceptionInterface {
     @Override
     public Boolean checkAllPhase(List<DoFundPhase1ResponseDto> doFundPhase1ResponseDtos, Optional<DoFundPhase2ResponseDto> doFundPhase2ResponseDto) {
 
-        if(doFundPhase1ResponseDtos.isEmpty() || doFundPhase2ResponseDto.isEmpty()){
-            return true;
-        }
-
-        return false;
+        return doFundPhase1ResponseDtos.isEmpty() || doFundPhase2ResponseDto.isEmpty();
     }
 
     // 입력한 펀딩 금액이 펀딩하고자 하는 총 리워드들의 금액보다 낮으면 결제 불가 처리
     @Override
     public Boolean checkInputQuantity(int inputQuantity, int compareTotalRewardQuantity) {
 
-        if(inputQuantity < compareTotalRewardQuantity){
-            return true;
-        }
+        return inputQuantity < compareTotalRewardQuantity;
+    }
 
-        return false;
+    // 이미 종료중인 프로젝트라면 펀딩을 할 수 없도록 처리
+    @Override
+    public Boolean checkProgressBeforeFunding(Long projectId) {
+
+        return jpaQueryFactory
+                .select(fundingProject.progress)
+                .from(fundingProject)
+                .where(fundingProject.fundingProjectId.eq(projectId))
+                .fetchOne().equals("종료");
     }
 }

--- a/src/main/java/com/example/zzapdiz/exception/dofundproject/DoFundProjectExceptionInterface.java
+++ b/src/main/java/com/example/zzapdiz/exception/dofundproject/DoFundProjectExceptionInterface.java
@@ -26,4 +26,7 @@ public interface DoFundProjectExceptionInterface {
 
     /** 입력한 펀딩 금액이 펀딩하고자 하는 총 리워드들의 금액보다 낮으면 결제 불가 처리 **/
     Boolean checkInputQuantity(int inputQuantity, int compareTotalRewardQuantity);
+
+    /** 이미 종료중인 프로젝트는 펀딩을 할 수 없음을 처리 **/
+    Boolean checkProgressBeforeFunding(Long projectId);
 }

--- a/src/main/java/com/example/zzapdiz/page/controller/PageController.java
+++ b/src/main/java/com/example/zzapdiz/page/controller/PageController.java
@@ -1,0 +1,30 @@
+package com.example.zzapdiz.page.controller;
+
+
+import com.example.zzapdiz.page.request.ExhibitionRequestDto;
+import com.example.zzapdiz.page.service.PageService;
+import com.example.zzapdiz.share.ResponseBody;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/zzapdiz/page")
+@RestController
+public class PageController {
+
+    private final PageService pageService;
+
+    // 짭디즈 메인 페이지 접속
+    @GetMapping("/main")
+    public ResponseEntity<ResponseBody> readMainPage(@RequestBody ExhibitionRequestDto exhibitionRequestDto){
+        log.info("짭디즈 메인 페이지 접속");
+
+        return pageService.readMainPage(exhibitionRequestDto);
+    }
+}

--- a/src/main/java/com/example/zzapdiz/page/request/ExhibitionRequestDto.java
+++ b/src/main/java/com/example/zzapdiz/page/request/ExhibitionRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.zzapdiz.page.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ExhibitionRequestDto {
+    private String exhibition1;
+    private String exhibition2;
+    private String exhibition3;
+}

--- a/src/main/java/com/example/zzapdiz/page/response/ExhibitionProjectsResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/page/response/ExhibitionProjectsResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.zzapdiz.page.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class ExhibitionProjectsResponseDto {
+    private Long fundingProjectId;
+    private String projectTitle;
+    private String projectCategory;
+    private int fundingCount;
+    private String thumbnailImage;
+}

--- a/src/main/java/com/example/zzapdiz/page/response/LankingProjectsResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/page/response/LankingProjectsResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.zzapdiz.page.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class LankingProjectsResponseDto {
+    private Long fundingProjectId;
+    private String reachPercentage;
+    private String projectCategory;
+}

--- a/src/main/java/com/example/zzapdiz/page/response/RecentOpenProjectsResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/page/response/RecentOpenProjectsResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.zzapdiz.page.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class RecentOpenProjectsResponseDto {
+    private Long fundingProjectId;
+    private String projectTile;
+    private String reachPercentage;
+    private String thumbnailImage;
+}

--- a/src/main/java/com/example/zzapdiz/page/response/SuitableProjectsResponseDto.java
+++ b/src/main/java/com/example/zzapdiz/page/response/SuitableProjectsResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.zzapdiz.page.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class SuitableProjectsResponseDto {
+    private Long fundingProjectId;
+    private String projectTitle;
+    private int fundingCount;
+    private String projectCategory;
+    private String thumbnailImage;
+}

--- a/src/main/java/com/example/zzapdiz/page/service/PageService.java
+++ b/src/main/java/com/example/zzapdiz/page/service/PageService.java
@@ -1,0 +1,57 @@
+package com.example.zzapdiz.page.service;
+
+import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.page.request.ExhibitionRequestDto;
+import com.example.zzapdiz.page.response.ExhibitionProjectsResponseDto;
+import com.example.zzapdiz.page.response.LankingProjectsResponseDto;
+import com.example.zzapdiz.page.response.RecentOpenProjectsResponseDto;
+import com.example.zzapdiz.page.response.SuitableProjectsResponseDto;
+import com.example.zzapdiz.share.ResponseBody;
+import com.example.zzapdiz.share.StatusCode;
+import com.example.zzapdiz.share.query.DynamicQueryDsl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PageService {
+
+    private final DynamicQueryDsl dynamicQueryDsl;
+
+    // 짭디즈 메인 페이지 접속
+    public ResponseEntity<ResponseBody> readMainPage(ExhibitionRequestDto exhibitionRequestDto) {
+        // 1. 취향저격 프로젝트 4개 조회
+        List<SuitableProjectsResponseDto> suitableProjects =  dynamicQueryDsl.getSuitableFundingProjects();
+
+        // 2. 메인 페이지에 접속하게 될 때 출력되어야 할 프로젝트 정보들 로직 생성 필요
+        List<LankingProjectsResponseDto> lankingProjects = dynamicQueryDsl.getLankingProjects();
+
+        // 3. 스토어 추천 제품 recommencStoreProjects (스토어 프로젝트 랜덤 6개)
+
+
+        // 4. 최근 오픈한 펀딩 프로젝트 recentProjects (가장 최근에 오픈한 펀딩 프로젝트 6개 리스트 업)
+        List<RecentOpenProjectsResponseDto> recentProjects = dynamicQueryDsl.getRecentProjects();
+
+        // 5. 기획전 exhibition (각각 다른 카테고리 3개 지정하여 생성 후 그 카테고리에 맞는 프로젝트 3개씩 리스트 업)
+        HashMap<String, List<ExhibitionProjectsResponseDto>> exhibitionProjects = dynamicQueryDsl.getExhibitionProjects(exhibitionRequestDto);
+
+        // 메인 페이지에 출력되어야할 프로젝트 정보들
+        LinkedHashMap<String, Object> resultSet = new LinkedHashMap<>();
+        resultSet.put("resultMessage", "메인 페이지 정보 출력 성공");
+        resultSet.put("suitableProjects", suitableProjects);
+        resultSet.put("lankingProjects", lankingProjects);
+//        resultSet.put("", ); - 스토어 추천 제품 리스트
+        resultSet.put("recentProjects", recentProjects);
+        resultSet.put("exhibitionProjects", exhibitionProjects);
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.OK, resultSet), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/zzapdiz/share/StatusCode.java
+++ b/src/main/java/com/example/zzapdiz/share/StatusCode.java
@@ -33,7 +33,8 @@ public enum StatusCode {
     INCORRECTABLE_DOFUND_INFO(469, "펀딩하려고 하는 정보가 옳바르지 않습니다."),
     CANT_FUND_MINE(470, "메이커께서 만드신 프로젝트는 스스로 펀딩하실 수 없습니다."),
     NOT_EXIST_FUND_DATA(471, "펀딩한 데이터가 존재하지 않습니다."),
-    CANT_FUNDING(472, "입력하신 금액이 적어 펀딩할 수 없습니다.");
+    CANT_FUNDING(472, "입력하신 금액이 적어 펀딩할 수 없습니다."),
+    CANT_FUND_FOR_END_PROJECT(473, "이미 종료된 프로젝트는 펀딩할 수 없습니다.");
 
 
 

--- a/src/main/java/com/example/zzapdiz/share/project/ProjectCategory.java
+++ b/src/main/java/com/example/zzapdiz/share/project/ProjectCategory.java
@@ -3,6 +3,8 @@ package com.example.zzapdiz.share.project;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @AllArgsConstructor
 @NoArgsConstructor
 public enum ProjectCategory {

--- a/src/test/java/com/example/zzapdiz/other/OtherTest.java
+++ b/src/test/java/com/example/zzapdiz/other/OtherTest.java
@@ -1,6 +1,7 @@
 package com.example.zzapdiz.other;
 
 import com.example.zzapdiz.fundingproject.domain.FundingProject;
+import com.example.zzapdiz.share.project.ProjectCategory;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.util.List;
 
 import static com.example.zzapdiz.fundingproject.domain.QFundingProject.fundingProject;
 
@@ -45,5 +47,12 @@ public class OtherTest {
 
         System.out.println("테스트 결과 보여주세요!!!!!!!!!!!!!!!!!!!!!");
 //        System.out.println(LocalDateTime.now().get);
+    }
+
+    @Test
+    void getCategories(){
+
+        System.out.println(ProjectCategory.values());
+
     }
 }


### PR DESCRIPTION
[Feature/MainPage/Read]
- PageController 메인 페이지 호출 api 1차 구현
- PageService 메인 페이지 호출 비즈니스 로직 1차 구현
- 3개의 기획전 카테고리 요청값을 전달받기 위한 ExhibitionRequestDto 객체 생성
- 취향저격 프로젝트들 호출 응답 객체 SuitableProjectsResponseDto 객체 생성
- 달성율에 따른 랭킹 프로젝트들 호출 응답 객체 LankingProjectsResponseDto 객체 생성
- 최신 생성 프로젝트들 호출 응답 객체 RecentOpenProjectsResponseDto 객체 생성
- 기획전에 해당되는 프로젝트들 호출 응답 객체 ExhibitionProjectsResponseDto 객체 생성
- 취향저격 프로젝트, 랭킹 프로젝트, 최신 생성 프로젝트, 기획전 프로젝트 조회를 위한 함수 DynamicQueryDsl 추가 업데이트
- 펀딩하기 api에 프로젝트가 종료중인 상태이면 펀딩할 수 없도록 DoFundException 인터페이스 추가 업데이트
- StatusCode 추가 업데이트

# 수정사항 - DoFundService 펀딩하기 1단계 api 비즈니스 로직 수정
기존에 펀딩하기 1단계에는 곧바로 Redis에 펀딩한 리워드들을 바로 저장해놓았더니 2개 이상이면 덮어씌워져서 결과적으로 1개만 저장되었었다.
따라서, 펀딩 프로젝트 생성 api 에서 했던 것처럼 펀딩하기 정보 자체는 doFund 엔티티에 저장하고 펀딩한 리워드들을 static 변수에 저장시켜놓고 최종 단계에 불러와서 저장하는 방식으로 수정.
결과적으로 펀딩 금액도 정상적으로 계산되어 반영되었다.

# 업데이트해야할 로직
추천 스토어 제품 리스트도 메인 페이지에 같이 출력되어야 하기 때문에 스토어 프로젝트 관련 api가 만들어지면 추가해줄 것 