### PR TITLE
DynamicQueryDsl 취향 저격 프로젝트들 조회 로직 수정 업데이트

### DIFF
--- a/src/main/java/com/example/zzapdiz/share/query/DynamicQueryDsl.java
+++ b/src/main/java/com/example/zzapdiz/share/query/DynamicQueryDsl.java
@@ -697,6 +697,10 @@ public class DynamicQueryDsl {
                 .orderBy(fundingProject.projectCategory.desc())
                 .fetch();
 
+        for(int i = 0 ; i < projectCategoryList.size() ; i++){
+            System.out.println("현재 존재하는 카테고리 수 : " + projectCategoryList.get(i));
+        }
+
         while (korCategoryList.size() <= 3) {
             System.out.println("프로젝트 카테고리 수 : " + projectCategoryList.size());
 
@@ -713,6 +717,10 @@ public class DynamicQueryDsl {
 
                 korCategoryList.add(category);
                 projectCategoryList.remove(randomNum);
+            }
+
+            if(projectCategoryList.size() == 0){
+                break;
             }
         }
 
@@ -839,7 +847,7 @@ public class DynamicQueryDsl {
 
         ExhibitionProjectsResponseDto[] exhibitionProjects = new ExhibitionProjectsResponseDto[fundingProjects.size()];
 
-        for (int i = 0; i < exhibitionProjects.length ; i++) {
+        for (int i = 0; i < exhibitionProjects.length; i++) {
             String thumbnailImage = jpaQueryFactory
                     .select(media.mediaUrl)
                     .from(media)
@@ -863,7 +871,7 @@ public class DynamicQueryDsl {
             exhibitionProjects[i] = exhibitionDto;
         }
 
-        return  Arrays.stream(exhibitionProjects).toList();
+        return Arrays.stream(exhibitionProjects).toList();
     }
 
 }


### PR DESCRIPTION
[Fix/GetSuitableFundingProjects]

DynamicQuerydsl 의 getSuitableFundingProjects 함수 로직 수정
[수정 사항]
기존에는 현재 존재하고 있는 프로젝트들의 공통된 카테고리 수를 집계화하여 3개 이상일 경우 while문을 통해 리스트에 넣는 작업을 코드로 넣었으나 3개 이상이 아닌 초기 상태의 경우는 해당 로직을 수행할 수 없어 이상이 발생함.
따라서, 3개 이하인 경우에 처리해야할 로직을 추가하여 수정